### PR TITLE
use <Self> instead of Self to fix errors in rust nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ impl TempFile {
     /// Create a new temporary file.
     #[inline(always)]
     pub fn new() -> io::Result<TempFile> {
-        Self::new_in(&env::temp_dir())
+        <Self>::new_in(&env::temp_dir())
     }
 
     /// Create a new temporary file in the specified directory.
@@ -44,7 +44,7 @@ impl TempFile {
     /// temporary file cleaner.
     #[inline(always)]
     pub fn shared(count: usize) -> io::Result<Vec<TempFile>> {
-        Self::shared_in(&env::temp_dir(), count)
+        <Self>::shared_in(&env::temp_dir(), count)
     }
 
     /// Same as `shared` but creates the file in the specified directory.


### PR DESCRIPTION
Fixes the following compiler error.

src/lib.rs:29:9: 29:21 error: failed to resolve. Use of undeclared type or module `Self`
src/lib.rs:29         Self::new_in(&env::temp_dir())
                      ^~~~~~~~~~~~
src/lib.rs:29:9: 29:21 error: unresolved name `Self::new_in`
src/lib.rs:29         Self::new_in(&env::temp_dir())
                      ^~~~~~~~~~~~
src/lib.rs:47:9: 47:24 error: failed to resolve. Use of undeclared type or module `Self`
src/lib.rs:47         Self::shared_in(&env::temp_dir(), count)
                      ^~~~~~~~~~~~~~~
src/lib.rs:47:9: 47:24 error: unresolved name `Self::shared_in`
src/lib.rs:47         Self::shared_in(&env::temp_dir(), count)
                      ^~~~~~~~~~~~~~~
error: aborting due to 4 previous errors
Could not compile `tempfile`.
