### PR TITLE
imp/unix: always cast cstr.as_ptr() to avoid issues with differing c_char types

### DIFF
--- a/src/imp/unix.rs
+++ b/src/imp/unix.rs
@@ -93,16 +93,18 @@ pub fn persist(old_path: &Path, new_path: &Path, overwrite: bool) -> io::Result<
         let old_path = try!(cstr(old_path));
         let new_path = try!(cstr(new_path));
         if overwrite {
-            if libc::rename(old_path.as_ptr(), new_path.as_ptr()) != 0 {
+            if libc::rename(old_path.as_ptr() as *const libc::c_char,
+                            new_path.as_ptr() as *const libc::c_char) != 0 {
                 return Err(io::Error::last_os_error())
             }
         } else {
-            if libc::link(old_path.as_ptr(), new_path.as_ptr()) != 0 {
+            if libc::link(old_path.as_ptr() as *const libc::c_char,
+                          new_path.as_ptr() as *const libc::c_char) != 0 {
                 return Err(io::Error::last_os_error());
             }
             // Ignore unlink errors. Can we do better?
             // On recent linux, we can use renameat2 to do this atomically.
-            let _ = libc::unlink(old_path.as_ptr());
+            let _ = libc::unlink(old_path.as_ptr() as *const libc::c_char);
         }
         Ok(())
     }


### PR DESCRIPTION
Ran into this issue on arm. Unclear why they differ, but I'd imagine it's due to a mismatch between rustc's libc and the libc crate.