### PR TITLE
Use target-specific dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ build = "build.rs"
 [dependencies]
 libc = "0.2"
 rand = "0.3"
+
+[target.'cfg(windows)'.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"
 


### PR DESCRIPTION
This will allow non-Windows builds to avoid downloading the winapi crates.