### PR TITLE
extend NamedTemporaryFile to support persisting securely created files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ license = "MIT/Apache-2.0"
 [dependencies]
 rand = "0.3"
 
+[dev-dependencies]
+tempdir = "0.3.5"
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 

--- a/src/imp/windows.rs
+++ b/src/imp/windows.rs
@@ -80,9 +80,13 @@ pub fn reopen(file: &File, path: &Path) -> io::Result<File> {
     }
 }
 
-pub fn persist(old_path: &Path, new_path: &Path, overwrite: bool) -> io::Result<()> {
+pub fn persist(old_path: &Path, new_path: &Path, overwrite: bool, deleted: bool) -> io::Result<()> {
     // TODO: We should probably do this in one-shot using SetFileInformationByHandle but the API is
     // really painful.
+
+    if deleted {
+        return Err(io::Error::new(io::ErrorKind::Other, "can't persist deleted temp files on this platform"));
+    }
 
     unsafe {
         let old_path_w = to_utf16(old_path);

--- a/tests/namedtempfile.rs
+++ b/tests/namedtempfile.rs
@@ -145,8 +145,9 @@ fn deleted_noclobber() {
     let tmp = NamedTempFile::new_deleted(&temp_dir).unwrap();
 
     // Will only actually be deleted on (modern) linux:
-    #[cfg(target_os = "linux")]
-    assert_eq!(0, fs::read_dir(&temp_dir).unwrap().count());
+    #[cfg(target_os = "linux")] {
+        assert_eq!(0, fs::read_dir(&temp_dir).unwrap().count());
+    }
 
     let dest = temp_dir.path().to_path_buf().join("foo");
 


### PR DESCRIPTION
Linux supports linking a securely created temporary file (`O_TMPFILE`) back into the filesystem, so long as it wasn't created with `O_EXCL`. I believe this will improve the performance (and security) of one of my applications.

This branch extends `NamedTemporaryFile` to create these unnamed temporary files, such that the existing interface is maintained: you can persist these unnamed `NamedTemporaryFile`s into the filesystem:

```rust
let tmp = NamedTempFile::new_deleted(&temp_dir).unwrap();
...
tmp.persist_noclobber(&some_directory).unwrap();
```

The code hasn't turned out that great:

 * I don't like the name `new_deleted`, nor `attempt_without_name`, nor ramming this support for unnamed temporary files into an interface named `NamedTemporaryFile`. I decided to add it to `NamedTemporaryFile` as it is where the `persist` functionality currently exists, and because we can gracefully fall-back to a real named file without breaking anyone, hopefully.
 * The `path()` function continues to exist, and returns an implementation detail: the path to the `/proc/self/fd..`. While not inherently harmful, this is at least confusing.
 * I cannot see how to `renameat2` directly into the filesystem, so for the `persist`-clobbering case, the code has to create yet another named temporary file, and link into that, then rename. This is horrible.
 * I haven't tested it on non-Linux, and suspect I've made some mistakes there.

Note that `NamedTemporaryFile`s can't end up marked as `deleted` on non-modern-linux platforms, so the error handling/fallback around those cases is less interesting (e.g. the bailing in the windows `persist` implementation).

So:

 * Should this functionality belong in this create?
 * Can anyone else think of a better interface or name?
 * Is there anything horribly wrong with what's here?
