### PR TITLE
fix up some errors in docs

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -119,8 +119,7 @@ pub fn tempdir_in<P: AsRef<Path>>(dir: P) -> io::Result<TempDir> {
 ///
 /// The [`TempDir`] type creates a directory on the file system that
 /// is deleted once it goes out of scope. At construction, the
-/// `TempDir` creates a new directory with a randomly generated name,
-/// and with a prefix of your choosing.
+/// `TempDir` creates a new directory with a randomly generated name.
 ///
 /// The default constructor, [`TempDir::new()`], creates directories in
 /// the location returned by [`std::env::temp_dir()`], but `TempDir`
@@ -236,10 +235,9 @@ impl TempDir {
         Builder::new().tempdir()
     }
 
-    /// Attempts to make a temporary directory inside of `tmpdir`
-    /// whose name will have the prefix `prefix`. The directory and
-    /// everything inside it will be automatically deleted once the
-    /// returned `TempDir` is destroyed.
+    /// Attempts to make a temporary directory inside of `dir`.
+    /// The directory and everything inside it will be automatically 
+    /// deleted once the returned `TempDir` is destroyed.
     ///
     /// # Errors
     ///
@@ -353,8 +351,7 @@ impl TempDir {
     ///
     /// # use std::io;
     /// # fn run() -> Result<(), io::Error> {
-    /// // Create a directory inside of `std::env::temp_dir()`, named with
-    /// // the prefix, "example".
+    /// // Create a directory inside of `std::env::temp_dir()`.
     /// let tmp_dir = TempDir::new()?;
     /// let file_path = tmp_dir.path().join("my-temporary-note.txt");
     /// let mut tmp_file = File::create(file_path)?;


### PR DESCRIPTION
Fixes #53 

We had some lingering references in the prose to some old method arguments on `TempDir`.