### PR TITLE
Reduce scope of unsafe code

### DIFF
--- a/src/file/imp/unix.rs
+++ b/src/file/imp/unix.rs
@@ -98,21 +98,21 @@ fn create_unix(dir: &Path) -> io::Result<File> {
     })
 }
 
-#[cfg(not(unix))]
+#[cfg(target_os = "redox")]
 unsafe fn stat(fd: RawFd) -> io::Result<stat_t> {
     let mut meta: stat_t = ::std::mem::zeroed();
     cvt_err(fstat(fd, &mut meta))?;
     Ok(meta)
 }
 
-#[cfg(not(unix))]
+#[cfg(target_os = "redox")]
 fn same_dev_ino(fa: &File, fb: &File) -> io::Result<bool> {
     let meta_a = unsafe { stat(fa.as_raw_fd())? };
     let meta_b = unsafe { stat(fb.as_raw_fd())? };
     Ok(meta_a.st_dev == meta_b.st_dev && meta_a.st_ino == meta_b.st_ino)
 }
 
-#[cfg(unix)]
+#[cfg(not(target_os = "redox"))]
 fn same_dev_ino(fa: &File, fb: &File) -> io::Result<bool> {
     use std::os::unix::fs::MetadataExt;
     let meta_a = fa.metadata()?;

--- a/src/file/imp/unix.rs
+++ b/src/file/imp/unix.rs
@@ -41,8 +41,8 @@ pub fn cstr(path: &Path) -> io::Result<CString> {
 
 #[cfg(not(target_os = "redox"))]
 pub fn create_named(path: &Path) -> io::Result<File> {
+    let path = cstr(path)?;
     unsafe {
-        let path = cstr(path)?;
         let fd = cvt_err(open(
             path.as_ptr() as *const c_char,
             O_CLOEXEC | O_EXCL | O_RDWR | O_CREAT,
@@ -74,8 +74,8 @@ fn create_unlinked(path: &Path) -> io::Result<File> {
 #[cfg(target_os = "linux")]
 pub fn create(dir: &Path) -> io::Result<File> {
     use libc::O_TMPFILE;
+    let path = cstr(dir)?;
     match unsafe {
-        let path = cstr(dir)?;
         open(
             path.as_ptr() as *const c_char,
             O_CLOEXEC | O_EXCL | O_TMPFILE | O_RDWR,
@@ -121,9 +121,9 @@ pub fn reopen(file: &File, path: &Path) -> io::Result<File> {
 
 #[cfg(not(target_os = "redox"))]
 pub fn persist(old_path: &Path, new_path: &Path, overwrite: bool) -> io::Result<()> {
+    let old_path = cstr(old_path)?;
+    let new_path = cstr(new_path)?;
     unsafe {
-        let old_path = cstr(old_path)?;
-        let new_path = cstr(new_path)?;
         if overwrite {
             cvt_err(rename(
                 old_path.as_ptr() as *const c_char,


### PR DESCRIPTION
There were a few low-hanging fruit with respect to unsafeness.

In one case (`reopen` on unix) unsafe is now completely unnecessary thanks to std.