### PR TITLE
Fix compile on wasm32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ license = "MIT/Apache-2.0"
 [dependencies]
 rand = "0.5"
 remove_dir_all = "0.5"
+cfg-if = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.27"

--- a/src/file/imp/mod.rs
+++ b/src/file/imp/mod.rs
@@ -1,11 +1,12 @@
-#[cfg(any(unix, target_os = "redox"))]
-mod unix;
-
-#[cfg(any(unix, target_os = "redox"))]
-pub use self::unix::*;
-
-#[cfg(windows)]
-mod windows;
-
-#[cfg(windows)]
-pub use self::windows::*;
+cfg_if! {
+    if #[cfg(any(unix, target_os = "redox"))] {
+        mod unix;
+        pub use self::unix::*;
+    } else if #[cfg(windows)] {
+        mod windows;
+        pub use self::windows::*;
+    } else {
+        mod other;
+        pub use self::other::*;
+    }
+}

--- a/src/file/imp/other.rs
+++ b/src/file/imp/other.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+use std::io;
+use std::fs::File;
+
+fn not_supported<T>() -> io::Result<T> {
+    Err(io::Error::new(io::ErrorKind::Other, "operation not supported on this platform"))
+}
+
+pub fn create_named(_path: &Path) -> io::Result<File> {
+    not_supported()
+}
+
+pub fn create(_dir: &Path) -> io::Result<File> {
+    not_supported()
+}
+
+pub fn reopen(_file: &File, _path: &Path) -> io::Result<File> {
+    not_supported()
+}
+
+pub fn persist(_old_path: &Path, _new_path: &Path, _overwrite: bool) -> io::Result<()> {
+    not_supported()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,8 @@
        html_root_url = "https://docs.rs/tempfile/2.2.0")]
 #![cfg_attr(test, deny(warnings))]
 
+#[macro_use]
+extern crate cfg_if;
 extern crate rand;
 extern crate remove_dir_all;
 


### PR DESCRIPTION
This commit "adds support" for the wasm32-unknown-unknown target by simply
defining stubs that return errors, and it'll be up to crates depending on
`tempfile` to ensure they don't use this at runtime on wasm.