### PR TITLE
Attach a path to errors where possible

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -12,6 +12,7 @@ use remove_dir_all::remove_dir_all;
 use std::path::{self, Path, PathBuf};
 use std::{fmt, fs, io};
 
+use error::IoErrorExt;
 use Builder;
 
 /// Create a new temporary directory.
@@ -368,7 +369,7 @@ impl TempDir {
     /// # }
     /// ```
     pub fn close(mut self) -> io::Result<()> {
-        let result = remove_dir_all(self.path());
+        let result = remove_dir_all(self.path()).map_err(|e| e.with_path(self.path()));
 
         // Prevent the Drop impl from removing the dir a second time.
         self.path = None;
@@ -400,7 +401,8 @@ impl Drop for TempDir {
     }
 }
 
-// pub(crate)
-pub fn create(path: PathBuf) -> io::Result<TempDir> {
-    fs::create_dir(&path).map(|_| TempDir { path: Some(path) })
+pub(crate) fn create(path: PathBuf) -> io::Result<TempDir> {
+    fs::create_dir(&path)
+        .map_err(|e| e.with_path(path.clone()))
+        .map(|_| TempDir { path: Some(path) })
 }

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -12,7 +12,7 @@ use remove_dir_all::remove_dir_all;
 use std::path::{self, Path, PathBuf};
 use std::{fmt, fs, io};
 
-use error::IoErrorExt;
+use error::IoResultExt;
 use Builder;
 
 /// Create a new temporary directory.
@@ -369,7 +369,7 @@ impl TempDir {
     /// # }
     /// ```
     pub fn close(mut self) -> io::Result<()> {
-        let result = remove_dir_all(self.path()).map_err(|e| e.with_path(self.path()));
+        let result = remove_dir_all(self.path()).with_err_path(|| self.path());
 
         // Prevent the Drop impl from removing the dir a second time.
         self.path = None;
@@ -403,6 +403,6 @@ impl Drop for TempDir {
 
 pub(crate) fn create(path: PathBuf) -> io::Result<TempDir> {
     fs::create_dir(&path)
-        .map_err(|e| e.with_path(path.clone()))
+        .with_err_path(|| &path)
         .map(|_| TempDir { path: Some(path) })
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,40 @@
+use std::{error, io, fmt};
+use std::path::PathBuf;
+
+#[derive(Debug)]
+struct PathError {
+    path: PathBuf,
+    err: io::Error,
+}
+
+impl fmt::Display for PathError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} at path {:?}", self.err, self.path)
+    }
+}
+
+impl error::Error for PathError {
+    fn description(&self) -> &str {
+        self.err.description()
+    }
+    
+    fn cause(&self) -> Option<&error::Error> {
+        self.err.cause()
+    }
+}
+
+pub(crate) trait IoErrorExt {
+    fn with_path<P>(self, path: P) -> Self where P: Into<PathBuf>;
+}
+
+impl IoErrorExt for io::Error {
+    fn with_path<P>(self, path: P) -> Self
+    where
+        P: Into<PathBuf>,
+    {
+        io::Error::new(self.kind(), PathError {
+            path: path.into(),
+            err: self,
+        })
+    }
+}

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -9,7 +9,7 @@ use std::mem;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-use error::IoErrorExt;
+use error::IoResultExt;
 use Builder;
 
 mod imp;
@@ -184,7 +184,7 @@ impl TempPath {
     /// # }
     /// ```
     pub fn close(mut self) -> io::Result<()> {
-        let result = fs::remove_file(&self.path).map_err(|e| e.with_path(&self.path));
+        let result = fs::remove_file(&self.path).with_err_path(|| &self.path);
         mem::replace(&mut self.path, PathBuf::new());
         mem::forget(self);
         result
@@ -705,7 +705,7 @@ impl NamedTempFile {
     /// # }
     /// ```
     pub fn reopen(&self) -> io::Result<File> {
-        imp::reopen(self.as_file(), NamedTempFile::path(self)).map_err(|e| e.with_path(NamedTempFile::path(self)))
+        imp::reopen(self.as_file(), NamedTempFile::path(self)).with_err_path(|| NamedTempFile::path(self))
     }
 
     /// Get a reference to the underlying file.
@@ -736,45 +736,45 @@ impl NamedTempFile {
 
 impl Read for NamedTempFile {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.as_file_mut().read(buf).map_err(|e| e.with_path(self.path()))
+        self.as_file_mut().read(buf).with_err_path(|| self.path())
     }
 }
 
 impl<'a> Read for &'a NamedTempFile {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.as_file().read(buf).map_err(|e| e.with_path(self.path()))
+        self.as_file().read(buf).with_err_path(|| self.path())
     }
 }
 
 impl Write for NamedTempFile {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.as_file_mut().write(buf).map_err(|e| e.with_path(self.path()))
+        self.as_file_mut().write(buf).with_err_path(|| self.path())
     }
     #[inline]
     fn flush(&mut self) -> io::Result<()> {
-        self.as_file_mut().flush().map_err(|e| e.with_path(self.path()))
+        self.as_file_mut().flush().with_err_path(|| self.path())
     }
 }
 
 impl<'a> Write for &'a NamedTempFile {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.as_file().write(buf).map_err(|e| e.with_path(self.path()))
+        self.as_file().write(buf).with_err_path(|| self.path())
     }
     #[inline]
     fn flush(&mut self) -> io::Result<()> {
-        self.as_file().flush().map_err(|e| e.with_path(self.path()))
+        self.as_file().flush().with_err_path(|| self.path())
     }
 }
 
 impl Seek for NamedTempFile {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        self.as_file_mut().seek(pos).map_err(|e| e.with_path(self.path()))
+        self.as_file_mut().seek(pos).with_err_path(|| self.path())
     }
 }
 
 impl<'a> Seek for &'a NamedTempFile {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        self.as_file().seek(pos).map_err(|e| e.with_path(self.path()))
+        self.as_file().seek(pos).with_err_path(|| self.path())
     }
 }
 
@@ -796,7 +796,7 @@ impl std::os::windows::io::AsRawHandle for NamedTempFile {
 
 pub(crate) fn create_named(path: PathBuf) -> io::Result<NamedTempFile> {
     imp::create_named(&path)
-        .map_err(|e| e.with_path(path.clone()))
+        .with_err_path(|| path.clone())
         .map(|file| NamedTempFile {
             path: TempPath { path },
             file,

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -9,6 +9,7 @@ use std::mem;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
+use error::IoErrorExt;
 use Builder;
 
 mod imp;
@@ -183,7 +184,7 @@ impl TempPath {
     /// # }
     /// ```
     pub fn close(mut self) -> io::Result<()> {
-        let result = fs::remove_file(&self.path);
+        let result = fs::remove_file(&self.path).map_err(|e| e.with_path(&self.path));
         mem::replace(&mut self.path, PathBuf::new());
         mem::forget(self);
         result
@@ -704,7 +705,7 @@ impl NamedTempFile {
     /// # }
     /// ```
     pub fn reopen(&self) -> io::Result<File> {
-        imp::reopen(self.as_file(), NamedTempFile::path(self))
+        imp::reopen(self.as_file(), NamedTempFile::path(self)).map_err(|e| e.with_path(NamedTempFile::path(self)))
     }
 
     /// Get a reference to the underlying file.
@@ -735,45 +736,45 @@ impl NamedTempFile {
 
 impl Read for NamedTempFile {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.as_file_mut().read(buf)
+        self.as_file_mut().read(buf).map_err(|e| e.with_path(self.path()))
     }
 }
 
 impl<'a> Read for &'a NamedTempFile {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.as_file().read(buf)
+        self.as_file().read(buf).map_err(|e| e.with_path(self.path()))
     }
 }
 
 impl Write for NamedTempFile {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.as_file_mut().write(buf)
+        self.as_file_mut().write(buf).map_err(|e| e.with_path(self.path()))
     }
     #[inline]
     fn flush(&mut self) -> io::Result<()> {
-        self.as_file_mut().flush()
+        self.as_file_mut().flush().map_err(|e| e.with_path(self.path()))
     }
 }
 
 impl<'a> Write for &'a NamedTempFile {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.as_file().write(buf)
+        self.as_file().write(buf).map_err(|e| e.with_path(self.path()))
     }
     #[inline]
     fn flush(&mut self) -> io::Result<()> {
-        self.as_file().flush()
+        self.as_file().flush().map_err(|e| e.with_path(self.path()))
     }
 }
 
 impl Seek for NamedTempFile {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        self.as_file_mut().seek(pos)
+        self.as_file_mut().seek(pos).map_err(|e| e.with_path(self.path()))
     }
 }
 
 impl<'a> Seek for &'a NamedTempFile {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        self.as_file().seek(pos)
+        self.as_file().seek(pos).map_err(|e| e.with_path(self.path()))
     }
 }
 
@@ -793,10 +794,11 @@ impl std::os::windows::io::AsRawHandle for NamedTempFile {
     }
 }
 
-// pub(crate)
-pub fn create_named(path: PathBuf) -> io::Result<NamedTempFile> {
-    imp::create_named(&path).map(|file| NamedTempFile {
-        path: TempPath { path },
-        file,
-    })
+pub(crate) fn create_named(path: PathBuf) -> io::Result<NamedTempFile> {
+    imp::create_named(&path)
+        .map_err(|e| e.with_path(path.clone()))
+        .map(|file| NamedTempFile {
+            path: TempPath { path },
+            file,
+        })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ const NUM_RAND_CHARS: usize = 6;
 use std::path::Path;
 use std::{env, io};
 
+mod error;
 mod dir;
 mod file;
 mod util;

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,8 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::{io, iter};
 
+use error::IoErrorExt;
+
 fn tmpname(prefix: &str, suffix: &str, rand_len: usize) -> OsString {
     let mut buf = String::with_capacity(prefix.len() + suffix.len() + rand_len);
     buf.push_str(prefix);
@@ -37,7 +39,9 @@ pub fn create_helper<F, R>(
 where
     F: Fn(PathBuf) -> io::Result<R>,
 {
-    for _ in 0..::NUM_RETRIES {
+    let num_retries = if random_len != 0 { ::NUM_RETRIES } else { 1 };
+
+    for _ in 0..num_retries {
         let path = base.join(tmpname(prefix, suffix, random_len));
         return match f(path) {
             Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
@@ -46,7 +50,7 @@ where
     }
 
     Err(io::Error::new(
-        io::ErrorKind::AlreadyExists,
-        "too many temporary files exist",
-    ))
+        io::ErrorKind::AlreadyExists, 
+        "too many temporary files exist")
+        .with_path(base))
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::{io, iter};
 
-use error::IoErrorExt;
+use error::IoResultExt;
 
 fn tmpname(prefix: &str, suffix: &str, rand_len: usize) -> OsString {
     let mut buf = String::with_capacity(prefix.len() + suffix.len() + rand_len);
@@ -51,6 +51,6 @@ where
 
     Err(io::Error::new(
         io::ErrorKind::AlreadyExists, 
-        "too many temporary files exist")
-        .with_path(base))
+        "too many temporary files exist"))
+        .with_err_path(|| base)
 }


### PR DESCRIPTION
Closes #71 

Adds an internal extension trait that lets us attach a `PathBuf` as context to an `io::Error` from temporary paths and directories when operations on them fail. It's not going to catch cases where we touch the underlying `File` itself, but should be a little more helpful for diagnostics.

cc @luser @Stebalien 