### PR TITLE
Fix nightly build

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,8 @@ impl error::Error for PathError {
     fn description(&self) -> &str {
         self.err.description()
     }
-    
+
+    #[allow(deprecated)]
     fn cause(&self) -> Option<&error::Error> {
         self.err.cause()
     }


### PR DESCRIPTION
`std::io::Error` hasn't implemented `Error::source`, so we can't use that yet. Adding `#[allow(deprecated)]` is a temporary fix until `std::io::Error` is updated.

The warning/error that is fixed:
```
warning: use of deprecated item 'std::error::Error::cause': replaced by Error::source, which can support downcasting
  --> src/error.rs:22:18
   |
22 |         self.err.cause()
   |                  ^^^^^
   |
   = note: #[warn(deprecated)] on by default
```