### PR TITLE
Change the builder to accept &AsRef<OsStr>

### DIFF
--- a/src/file/imp/unix.rs
+++ b/src/file/imp/unix.rs
@@ -1,6 +1,6 @@
 #[cfg(not(target_os = "redox"))]
 use libc::{c_char, c_int, link, rename, unlink, O_CLOEXEC, O_CREAT, O_EXCL, O_RDWR};
-use std::ffi::CString;
+use std::ffi::{CString, OsStr};
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::os::unix::ffi::OsStrExt;
@@ -93,9 +93,13 @@ pub fn create(dir: &Path) -> io::Result<File> {
 }
 
 fn create_unix(dir: &Path) -> io::Result<File> {
-    util::create_helper(dir, ".tmp", "", ::NUM_RAND_CHARS, |path| {
-        create_unlinked(&path)
-    })
+    util::create_helper(
+        dir,
+        OsStr::new(".tmp"),
+        OsStr::new(""),
+        ::NUM_RAND_CHARS,
+        |path| create_unlinked(&path),
+    )
 }
 
 unsafe fn stat(fd: RawFd) -> io::Result<stat_t> {

--- a/src/file/imp/windows.rs
+++ b/src/file/imp/windows.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io;
 use std::os::windows::ffi::OsStrExt;
@@ -8,8 +9,8 @@ use std::ptr;
 use winapi::shared::minwindef::DWORD;
 use winapi::um::fileapi::{CreateFileW, SetFileAttributesW, CREATE_NEW};
 use winapi::um::handleapi::INVALID_HANDLE_VALUE;
-use winapi::um::winbase::{FILE_FLAG_DELETE_ON_CLOSE, MOVEFILE_REPLACE_EXISTING};
 use winapi::um::winbase::{MoveFileExW, ReOpenFile};
+use winapi::um::winbase::{FILE_FLAG_DELETE_ON_CLOSE, MOVEFILE_REPLACE_EXISTING};
 use winapi::um::winnt::{FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_TEMPORARY};
 use winapi::um::winnt::{FILE_GENERIC_READ, FILE_GENERIC_WRITE, HANDLE};
 use winapi::um::winnt::{FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE};
@@ -64,15 +65,21 @@ pub fn create_named(path: &Path) -> io::Result<File> {
 }
 
 pub fn create(dir: &Path) -> io::Result<File> {
-    util::create_helper(dir, ".tmp", "", ::NUM_RAND_CHARS, |path| {
-        win_create(
-            &path,
-            ACCESS,
-            0, // Exclusive
-            CREATE_NEW,
-            FLAGS | FILE_FLAG_DELETE_ON_CLOSE,
-        )
-    })
+    util::create_helper(
+        dir,
+        OsStr::new(".tmp"),
+        OsStr::new(""),
+        ::NUM_RAND_CHARS,
+        |path| {
+            win_create(
+                &path,
+                ACCESS,
+                0, // Exclusive
+                CREATE_NEW,
+                FLAGS | FILE_FLAG_DELETE_ON_CLOSE,
+            )
+        },
+    )
 }
 
 pub fn reopen(file: &File, _path: &Path) -> io::Result<File> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ extern crate syscall;
 const NUM_RETRIES: u32 = 1 << 31;
 const NUM_RAND_CHARS: usize = 6;
 
+use std::ffi::OsStr;
 use std::path::Path;
 use std::{env, io};
 
@@ -128,16 +129,16 @@ pub use spooled::{spooled_tempfile, SpooledTempFile};
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Builder<'a, 'b> {
     random_len: usize,
-    prefix: &'a str,
-    suffix: &'b str,
+    prefix: &'a OsStr,
+    suffix: &'b OsStr,
 }
 
 impl<'a, 'b> Default for Builder<'a, 'b> {
     fn default() -> Self {
         Builder {
             random_len: ::NUM_RAND_CHARS,
-            prefix: ".tmp",
-            suffix: "",
+            prefix: OsStr::new(".tmp"),
+            suffix: OsStr::new(""),
         }
     }
 }
@@ -241,8 +242,8 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn prefix(&mut self, prefix: &'a str) -> &mut Self {
-        self.prefix = prefix;
+    pub fn prefix<S: AsRef<OsStr> + ?Sized>(&mut self, prefix: &'a S) -> &mut Self {
+        self.prefix = prefix.as_ref();
         self
     }
 
@@ -269,8 +270,8 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn suffix(&mut self, suffix: &'b str) -> &mut Self {
-        self.suffix = suffix;
+    pub fn suffix<S: AsRef<OsStr> + ?Sized>(&mut self, suffix: &'b S) -> &mut Self {
+        self.suffix = suffix.as_ref();
         self
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,38 +1,32 @@
-use rand;
-use rand::RngCore;
-use std::ffi::OsString;
+use rand::distributions::Alphanumeric;
+use rand::{self, Rng};
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
-use std::{io, iter};
+use std::{io, str};
 
 use error::IoResultExt;
 
-fn tmpname(prefix: &str, suffix: &str, rand_len: usize) -> OsString {
-    let mut buf = String::with_capacity(prefix.len() + suffix.len() + rand_len);
-    buf.push_str(prefix);
-    buf.extend(iter::repeat('X').take(rand_len));
-    buf.push_str(suffix);
+fn tmpname(prefix: &OsStr, suffix: &OsStr, rand_len: usize) -> OsString {
+    let mut buf = OsString::with_capacity(prefix.len() + suffix.len() + rand_len);
+    buf.push(prefix);
 
-    // Randomize.
+    // Push each character in one-by-one. Unfortunately, this is the only
+    // safe(ish) simple way to do this without allocating a temporary
+    // String/Vec.
     unsafe {
-        // We guarantee utf8.
-        let bytes = &mut buf.as_mut_vec()[prefix.len()..prefix.len() + rand_len];
-        rand::thread_rng().fill_bytes(bytes);
-        for byte in bytes.iter_mut() {
-            *byte = match *byte % 62 {
-                v @ 0...9 => (v + b'0'),
-                v @ 10...35 => (v - 10 + b'a'),
-                v @ 36...61 => (v - 36 + b'A'),
-                _ => unreachable!(),
-            }
-        }
+        rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(rand_len)
+            .for_each(|b| buf.push(str::from_utf8_unchecked(&[b as u8])))
     }
-    OsString::from(buf)
+    buf.push(suffix);
+    return buf;
 }
 
 pub fn create_helper<F, R>(
     base: &Path,
-    prefix: &str,
-    suffix: &str,
+    prefix: &OsStr,
+    suffix: &OsStr,
     random_len: usize,
     f: F,
 ) -> io::Result<R>


### PR DESCRIPTION
This covers `&str`, `&OsStr`, etc. I'd rather take `AsRef<OsStr>` however, we'd then need to somehow own the content so we'd need to make the builder generic (and completely change the API).

fixes #58.

* [x] TODO: Check the most popular dependent crates for breakage. This may affect type inference.