### PR TITLE
Use absolute paths

### DIFF
--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -795,7 +795,12 @@ impl std::os::windows::io::AsRawHandle for NamedTempFile {
     }
 }
 
-pub(crate) fn create_named(path: PathBuf) -> io::Result<NamedTempFile> {
+pub(crate) fn create_named(mut path: PathBuf) -> io::Result<NamedTempFile> {
+    // Make the path absolute. Otherwise, changing directories could cause us to
+    // delete the wrong file.
+    if !path.is_absolute() {
+        path = env::current_dir()?.join(path)
+    }
     imp::create_named(&path)
         .with_err_path(|| path.clone())
         .map(|file| NamedTempFile {

--- a/tests/namedtempfile.rs
+++ b/tests/namedtempfile.rs
@@ -207,3 +207,13 @@ fn test_write_after_close() {
     let path = NamedTempFile::new().unwrap().into_temp_path();
     File::create(path).unwrap().write_all(b"test").unwrap();
 }
+
+#[test]
+fn test_change_dir() {
+    env::set_current_dir(env::temp_dir()).unwrap();
+    let tmpfile = NamedTempFile::new_in(".").unwrap();
+    let path = env::current_dir().unwrap().join(tmpfile.path());
+    env::set_current_dir("/").unwrap();
+    drop(tmpfile);
+    assert!(!exists(path))
+}


### PR DESCRIPTION
When looking into #40, I realized we weren't actually _doing_ what I claimed. Except for never-named tempfiles on Linux and auto-removed temporary files on Windows, we need to use absolute path names to guard against changes in the current working directory.

Unfortunately, this is a **[breaking change]** on some unix-like OSs. It's possible to:

1. Chdir to a directory.
2. Chmod the parent directory to remove the search (`x`) permission.

This will break any uses of absolute path names. The solution is the one described in #40: open the current directory, use `openat` on the relative path, and then close the current directory. However:

1. This will only help with unnamed temporary files unless we're willing to _hold_ the file directory open (probably not the best idea).
2. This will require two filesystem extra syscalls (instead of one as with getcwd).