### PR TITLE
feat: modernize errors and bump minimum version to 1.30

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.24.0
+  - 1.30.1
 os:
   - linux
   - osx

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ patterns and surprisingly difficult to implement securely).
 Usage
 -----
 
-Minimum required Rust version: 1.24.0
+Minimum required Rust version: 1.30.1
 
 Add this to your `Cargo.toml`:
 ```toml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
   matrix:
     - RUST_INSTALL_TRIPLE: i686-pc-windows-msvc
       VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat"
-      RUST_VERSION: 1.24.0
+      RUST_VERSION: 1.30.1
     - RUST_INSTALL_TRIPLE: i686-pc-windows-msvc
       VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat"
       RUST_VERSION: beta
@@ -18,7 +18,7 @@ environment:
       RUST_VERSION: nightly
     - RUST_INSTALL_TRIPLE: x86_64-pc-windows-msvc
       VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
-      RUST_VERSION: 1.24.0
+      RUST_VERSION: 1.30.1
     - RUST_INSTALL_TRIPLE: x86_64-pc-windows-msvc
       VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
       RUST_VERSION: beta

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,13 +14,8 @@ impl fmt::Display for PathError {
 }
 
 impl error::Error for PathError {
-    fn description(&self) -> &str {
-        self.err.description()
-    }
-
-    #[allow(deprecated)]
-    fn cause(&self) -> Option<&error::Error> {
-        self.err.cause()
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        self.err.source()
     }
 }
 

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -129,11 +129,7 @@ impl fmt::Display for PathPersistError {
 }
 
 impl error::Error for PathPersistError {
-    fn description(&self) -> &str {
-        "failed to persist temporary file path"
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         Some(&self.error)
     }
 }
@@ -523,10 +519,7 @@ impl fmt::Display for PersistError {
 }
 
 impl error::Error for PersistError {
-    fn description(&self) -> &str {
-        "failed to persist temporary file"
-    }
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         Some(&self.error)
     }
 }


### PR DESCRIPTION
This:

* Fixes some deprecation warnings.
* Removes the description function implementation.
* Replaces `cause` with `source` for improved downcasting.