### PR TITLE
bump rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT/Apache-2.0"
 exclude = ["/.travis.yml", "/appveyor.yml"]
 
 [dependencies]
-rand = "0.6"
+rand = "0.7"
 remove_dir_all = "0.5"
 cfg-if = "0.1"
 


### PR DESCRIPTION
Tests are green for me on linux.

New `rand` has a significantly less disgusting dependency tree.