### PR TITLE
build: Bump libc to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rand = "0.7"
 remove_dir_all = "0.5"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.27"
+libc = "0.2"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"


### PR DESCRIPTION
Instead of specifying the `libc` crate dependency with PATCH version, I would suggest to use only the MINOR version.