### PR TITLE
build: Allow newer libc versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rand = "0.7"
 remove_dir_all = "0.5"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.27"
+libc = "^0.2.27"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"


### PR DESCRIPTION
Follow up on #104 , using the caret form of the version definition.