### PR TITLE
ref: replace rand with fastrand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ description = "A library for managing temporary files and directories."
 
 [dependencies]
 cfg-if = "0.1"
-fastrand = "1.2.2"
+fastrand = "1.2.3"
 remove_dir_all = "0.5"
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ description = "A library for managing temporary files and directories."
 
 [dependencies]
 cfg-if = "0.1"
-fastrand = "1.1"
+fastrand = "1.2.2"
 remove_dir_all = "0.5"
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ description = "A library for managing temporary files and directories."
 
 [dependencies]
 cfg-if = "0.1"
-rand = "0.7"
+fastrand = "1.1"
 remove_dir_all = "0.5"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,24 +1,17 @@
-use rand::distributions::Alphanumeric;
-use rand::{self, Rng};
+use fastrand;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
-use std::{io, str};
+use std::{io, iter::repeat_with};
 
 use crate::error::IoResultExt;
 
 fn tmpname(prefix: &OsStr, suffix: &OsStr, rand_len: usize) -> OsString {
     let mut buf = OsString::with_capacity(prefix.len() + suffix.len() + rand_len);
     buf.push(prefix);
-
-    // Push each character in one-by-one. Unfortunately, this is the only
-    // safe(ish) simple way to do this without allocating a temporary
-    // String/Vec.
-    unsafe {
-        rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(rand_len)
-            .for_each(|b| buf.push(str::from_utf8_unchecked(&[b as u8])))
-    }
+    buf.push(repeat_with(fastrand::alphanumeric)
+        .take(rand_len)
+        .collect::<String>()
+    );
     buf.push(suffix);
     buf
 }


### PR DESCRIPTION
rand's a fairly heavy dependency. There's the recent https://github.com/stjepang/fastrand crate which has **zero dependencies**, and works great if you don't need cryptographically secure random data.

If this is a welcome change, I can also update NEWS.

Also, I wasn't able to glean from git blame the aversion to the temporarily allocated String. But if that's desired then I can also try and find a way to avoid that, but I don't think it's a big deal.