### PR TITLE
ref: use SmallRng

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ description = "A library for managing temporary files and directories."
 
 [dependencies]
 cfg-if = "1"
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng", "getrandom"], default_features = false }
 remove_dir_all = "0.5"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Alternative to https://github.com/Stebalien/tempfile/pull/118.

My understanding is that SmallRng is much smaller and cheaper to initialize than the thread_rng, which is a thread-local ThreadRng (StdRng, with the added overhead of ReseedingRng because it needs to be secure). SmallRng is also faster than StdRng. This is all because SmallRng is not a CSPRNG.

It's worth noting that unreleased rand at this time also shakes rand_chacha from the dependency tree, which is really nice. I believe rand's planning on releasing 0.8, so if this PR looks good, I'd recommend blocking on that. Issues: https://github.com/rust-random/rand/issues/965, https://github.com/rust-random/rand/issues/938.