### PR TITLE
fix build error from remove_dir_all version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.32.0
+  - 1.40.0
 os:
   - linux
   - osx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ description = "A library for managing temporary files and directories."
 [dependencies]
 cfg-if = "0.1"
 rand = "0.7"
-remove_dir_all = "0.5"
+remove_dir_all = "=0.5.3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ description = "A library for managing temporary files and directories."
 [dependencies]
 cfg-if = "0.1"
 rand = "0.7"
-remove_dir_all = "=0.5.3"
+remove_dir_all = "0.5"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.27"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ patterns and surprisingly difficult to implement securely).
 Usage
 -----
 
-Minimum required Rust version: 1.32.0
+Minimum required Rust version: 1.40.0
 
 Add this to your `Cargo.toml`:
 ```toml


### PR DESCRIPTION
The release of remove_dir_all version 0.5.3 increased the implicit MSRV of that crate to 1.40.0. The policy of the author of that crate is to support only the current stable version of Rust and to not treat a change in the implicit MSRV as a breaking change (see #XAMPPRocky/remove_dir_all#21). The author of that crate recommends pinning to an earlier version to continue to support an earlier MSRV.

Increase the MSRV in this crate to 1.40.0 to allow it to compile with remove_dir_all version 0.5.3. Also pin remove_dir_all to version 0.5.3 to avoid a caret dependency that could break this crate's MSRV unexpectedly based on future changes to remove_dir_all. 

Closes: #120