### PR TITLE
Add builder() shortcut method to TempDir / TempFile

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -263,6 +263,13 @@ impl TempDir {
         Builder::new().tempdir_in(dir)
     }
 
+    /// Shortcut for [`Builder::new()`].
+    ///
+    /// [`Builder::new()`]: struct.Builder.html#method.new
+    pub fn builder<'a, 'b>() -> Builder<'a, 'b> {
+        Builder::new()
+    }
+
     /// Accesses the [`Path`] to the temporary directory.
     ///
     /// [`Path`]: http://doc.rust-lang.org/std/path/struct.Path.html

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -590,6 +590,13 @@ impl NamedTempFile {
         Builder::new().tempfile_in(dir)
     }
 
+    /// Shortcut for [`Builder::new()`].
+    ///
+    /// [`Builder::new()`]: struct.Builder.html#method.new
+    pub fn builder<'a, 'b>() -> Builder<'a, 'b> {
+        Builder::new()
+    }
+
     /// Get the temporary file's path.
     ///
     /// # Security

--- a/tests/tempdir.rs
+++ b/tests/tempdir.rs
@@ -259,3 +259,9 @@ fn main() {
     in_tmpdir(dont_double_panic);
     in_tmpdir(pass_as_asref_path);
 }
+
+#[test]
+fn builder_shortcut() {
+    let mut builder = TempDir::builder();
+    builder.prefix("testing").tempdir().unwrap();
+}


### PR DESCRIPTION
In the source code, using `TempDir::builder()` is more expressive than `Builder::new()`.