### PR TITLE
Update rand to 0.8, redox_syscall to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ features = [
 ]
 
 [target.'cfg(target_os = "redox")'.dependencies]
-redox_syscall = "0.1"
+redox_syscall = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ description = "A library for managing temporary files and directories."
 
 [dependencies]
 cfg-if = "1"
-rand = "0.7"
+rand = "0.8"
 remove_dir_all = "0.5"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Closes #134

Updating remove_dir_all seems controversial (#123), so this only updates old dependencies other than remove_dir_all.
