### PR TITLE
Add [limited] support for WASI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,15 @@ rust:
 os:
   - linux
   - osx
+env:
+  - CARGO_FLAGS=
+script:
+  - cargo test --verbose $CARGO_FLAGS
+jobs:
+  include:
+    - rust: 1.40.0
+      os: linux
+      env: CARGO_FLAGS=--target wasm32-wasi
+    - rust: nightly
+      os: linux
+      env: CARGO_FLAGS=--target wasm32-wasi --features nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cfg-if = "1"
 rand = "0.8"
 remove_dir_all = "0.5"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
 libc = "0.2.27"
 
 [target.'cfg(windows)'.dependencies.winapi]
@@ -34,3 +34,6 @@ features = [
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.2"
+
+[features]
+nightly = []

--- a/src/file/imp/mod.rs
+++ b/src/file/imp/mod.rs
@@ -1,5 +1,5 @@
 cfg_if! {
-    if #[cfg(any(unix, target_os = "redox"))] {
+    if #[cfg(any(unix, target_os = "redox", target_os = "wasi"))] {
         mod unix;
         pub use self::unix::*;
     } else if #[cfg(windows)] {

--- a/src/file/imp/unix.rs
+++ b/src/file/imp/unix.rs
@@ -2,10 +2,18 @@ use std::env;
 use std::ffi::{CString, OsStr};
 use std::fs::{self, File, OpenOptions};
 use std::io;
-use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
-use std::path::Path;
+cfg_if! {
+    if #[cfg(not(target_os = "wasi"))] {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    } else {
+        use std::os::wasi::ffi::OsStrExt;
+        #[cfg(feature = "nightly")]
+        use std::os::wasi::fs::MetadataExt;
+    }
+}
 use crate::util;
+use std::path::Path;
 
 #[cfg(not(target_os = "redox"))]
 use libc::{c_char, c_int, link, rename, unlink};
@@ -33,12 +41,14 @@ pub fn cstr(path: &Path) -> io::Result<CString> {
 }
 
 pub fn create_named(path: &Path, open_options: &mut OpenOptions) -> io::Result<File> {
-    open_options
-        .read(true)
-        .write(true)
-        .create_new(true)
-        .mode(0o600)
-        .open(path)
+    open_options.read(true).write(true).create_new(true);
+
+    #[cfg(not(target_os = "wasi"))]
+    {
+        open_options.mode(0o600);
+    }
+
+    open_options.open(path)
 }
 
 fn create_unlinked(path: &Path) -> io::Result<File> {
@@ -94,11 +104,20 @@ pub fn reopen(file: &File, path: &Path) -> io::Result<File> {
     let new_file = OpenOptions::new().read(true).write(true).open(path)?;
     let old_meta = file.metadata()?;
     let new_meta = new_file.metadata()?;
-    if old_meta.dev() != new_meta.dev() || old_meta.ino() != new_meta.ino() {
-        return Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            "original tempfile has been replaced",
-        ));
+    cfg_if! {
+        if #[cfg(any(not(target_os = "wasi"), feature = "nightly"))] {
+            if old_meta.dev() != new_meta.dev() || old_meta.ino() != new_meta.ino() {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "original tempfile has been replaced",
+                ));
+            }
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "this operation is supported on WASI only on nightly Rust (with `nightly` feature enabled)"
+            ));
+        }
     }
     Ok(new_file)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@
 #![cfg_attr(test, deny(warnings))]
 #![deny(rust_2018_idioms)]
 #![allow(clippy::redundant_field_names)]
+#![cfg_attr(feature = "nightly", feature(wasi_ext))]
 
 #[macro_use]
 extern crate cfg_if;


### PR DESCRIPTION
WASI doesn't have a concept of system-wide temporary directory, but at least there is no reason why `new_in` methods with explicit paths should fail.

This PR implements support for such methods.