### PR TITLE
use rand's SmallRng for random number generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ description = "A library for managing temporary files and directories."
 
 [dependencies]
 cfg-if = "1"
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng", "getrandom"], default_features = false }
 remove_dir_all = "0.5"
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dependencies]


### PR DESCRIPTION
#119 seems to have not been updated, so here's another take at it, trying to keep the diff as small as possible.

This approach stores a `SmallRng` as a thread-local variable, basically [directly copying the way `rand` does its own `thread_rng()`](https://github.com/rust-random/rand/blob/master/src/rngs/thread.rs) so as to avoid any issues or incompatibilities.

I opted not to further change the way that the `OsString` is built since that feels like it may be better in another PR.