### PR TITLE
Remove `O_EXCL` to allow for tmpfile persistence on Linux

### DIFF
--- a/src/file/imp/unix.rs
+++ b/src/file/imp/unix.rs
@@ -70,11 +70,11 @@ fn create_unlinked(path: &Path) -> io::Result<File> {
 
 #[cfg(target_os = "linux")]
 pub fn create(dir: &Path) -> io::Result<File> {
-    use libc::{EISDIR, ENOENT, EOPNOTSUPP, O_EXCL, O_TMPFILE};
+    use libc::{EISDIR, ENOENT, EOPNOTSUPP, O_TMPFILE};
     OpenOptions::new()
         .read(true)
         .write(true)
-        .custom_flags(O_TMPFILE | O_EXCL) // do not mix with `create_new(true)`
+        .custom_flags(O_TMPFILE) // do not mix with `create_new(true)`
         .open(dir)
         .or_else(|e| {
             match e.raw_os_error() {


### PR DESCRIPTION
Per #137 this PR remove the `O_EXCL` flag on Linux to enable Linux users to persist temp files without copying their contents.

### Example Usage

```rust
// Note: Persisting tmp files will not work if the tmp directory and
// permanent directory are not on the same file system
let file = tmpfile::tmpfile_in(some_directory_on_the_same_fs);

// TODO: Write to the tmp file like normal here
// ...

// Use /proc/self/fd/ to get a file path for the unnamed temp file
let tmp_file_path = format!("/proc/self/fd/{}", file.as_raw_fd());

// Persist the temp file to a new named path
nix::unistd::linkat(
    None,
    &tmp_file_path[..],
    None,
    &file_path[..],
    nix::unistd::LinkatFlags::SymlinkFollow,
)?;
```