### PR TITLE
Replace unsafe code from util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ description = "A library for managing temporary files and directories."
 
 [dependencies]
 cfg-if = "1"
-rand = { version = "0.8", features = ["small_rng", "getrandom"], default_features = false }
+rand = "0.8"
 remove_dir_all = "0.5"
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dependencies]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
 use rand::distributions::Alphanumeric;
-use rand::{self, Rng};
+use rand::Rng;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::io;
@@ -14,11 +14,13 @@ fn tmpname(prefix: &OsStr, suffix: &OsStr, rand_len: usize) -> OsString {
     // simple(ish) way to do this without allocating a temporary String/Vec.
     
     rand::thread_rng()
-        .sample_iter(&Alphanumeric)
+        .sample_iter(Alphanumeric)
         .take(rand_len)
         .for_each(|b| {
-            let mut chr = [0u8; 4];
-            buf.push(char::from(b).encode_utf8(&mut chr))
+            let mut chr = [0u8; 1];
+            if b < 128 {
+                buf.push(char::from(b).encode_utf8(&mut chr));
+            }
         });
 
     buf.push(suffix);


### PR DESCRIPTION
This patch does two things

1. Reverts #141 by removing hand spun thread local SmallRng that used unsafe
   P.S. Not sure but is it a security vulnerability to use a non CSPRNG for temporary filenames?
2. Replace use of str::from_utf8_unchecked with char::encode_utf8
   Examining the assembly shows no panics generated from encode_utf8


The only functional difference of this patch is replacing SmallRng with
a marginally slower RNG