### PR TITLE
Reduce size of TempDir and TempPath

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use remove_dir_all::remove_dir_all;
+use std::mem;
 use std::path::{self, Path, PathBuf};
 use std::{fmt, fs, io};
 
@@ -192,7 +193,7 @@ pub fn tempdir_in<P: AsRef<Path>>(dir: P) -> io::Result<TempDir> {
 /// [`std::fs`]: http://doc.rust-lang.org/std/fs/index.html
 /// [`std::process::exit()`]: http://doc.rust-lang.org/std/process/fn.exit.html
 pub struct TempDir {
-    path: Option<Box<Path>>,
+    path: Box<Path>,
 }
 
 impl TempDir {
@@ -292,7 +293,7 @@ impl TempDir {
     /// # }
     /// ```
     pub fn path(&self) -> &path::Path {
-        self.path.as_ref().unwrap()
+        self.path.as_ref()
     }
 
     /// Persist the temporary directory to disk, returning the [`PathBuf`] where it is located.
@@ -322,8 +323,13 @@ impl TempDir {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn into_path(mut self) -> PathBuf {
-        self.path.take().unwrap().into()
+    pub fn into_path(self) -> PathBuf {
+        // Prevent the Drop impl from being called.
+        let mut this = mem::ManuallyDrop::new(self);
+
+        // replace this.path with an empty Box, since an empty Box does not
+        // allocate any heap memory.
+        mem::replace(&mut this.path, PathBuf::new().into_boxed_path()).into()
     }
 
     /// Closes and removes the temporary directory, returning a `Result`.
@@ -369,8 +375,12 @@ impl TempDir {
     pub fn close(mut self) -> io::Result<()> {
         let result = remove_dir_all(self.path()).with_err_path(|| self.path());
 
-        // Prevent the Drop impl from removing the dir a second time.
-        self.path = None;
+        // Set self.path to empty Box to release the memory, since an empty
+        // Box does not allocate any heap memory.
+        self.path = PathBuf::new().into_boxed_path();
+
+        // Prevent the Drop impl from being called.
+        mem::forget(self);
 
         result
     }
@@ -392,10 +402,7 @@ impl fmt::Debug for TempDir {
 
 impl Drop for TempDir {
     fn drop(&mut self) {
-        // Path is `None` if `close()` or `into_path()` has been called.
-        if let Some(ref p) = self.path {
-            let _ = remove_dir_all(p);
-        }
+        let _ = remove_dir_all(self.path());
     }
 }
 
@@ -403,6 +410,6 @@ pub(crate) fn create(path: PathBuf) -> io::Result<TempDir> {
     fs::create_dir(&path)
         .with_err_path(|| &path)
         .map(|_| TempDir {
-            path: Some(path.into_boxed_path()),
+            path: path.into_boxed_path(),
         })
 }

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -192,7 +192,7 @@ pub fn tempdir_in<P: AsRef<Path>>(dir: P) -> io::Result<TempDir> {
 /// [`std::fs`]: http://doc.rust-lang.org/std/fs/index.html
 /// [`std::process::exit()`]: http://doc.rust-lang.org/std/process/fn.exit.html
 pub struct TempDir {
-    path: Option<PathBuf>,
+    path: Option<Box<Path>>,
 }
 
 impl TempDir {
@@ -323,7 +323,7 @@ impl TempDir {
     /// # }
     /// ```
     pub fn into_path(mut self) -> PathBuf {
-        self.path.take().unwrap()
+        self.path.take().unwrap().into()
     }
 
     /// Closes and removes the temporary directory, returning a `Result`.
@@ -402,5 +402,7 @@ impl Drop for TempDir {
 pub(crate) fn create(path: PathBuf) -> io::Result<TempDir> {
     fs::create_dir(&path)
         .with_err_path(|| &path)
-        .map(|_| TempDir { path: Some(path) })
+        .map(|_| TempDir {
+            path: Some(path.into_boxed_path()),
+        })
 }

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -138,7 +138,7 @@ impl error::Error for PathPersistError {
 ///
 /// When dropped, the temporary file is deleted.
 pub struct TempPath {
-    path: PathBuf,
+    path: Box<Path>,
 }
 
 impl TempPath {
@@ -176,8 +176,8 @@ impl TempPath {
     /// # }
     /// ```
     pub fn close(mut self) -> io::Result<()> {
-        let result = fs::remove_file(&self.path).with_err_path(|| &self.path);
-        self.path = PathBuf::new();
+        let result = fs::remove_file(&self.path).with_err_path(|| &*self.path);
+        self.path = PathBuf::new().into_boxed_path();
         mem::forget(self);
         result
     }
@@ -231,7 +231,7 @@ impl TempPath {
                 // Don't drop `self`. We don't want to try deleting the old
                 // temporary file path. (It'll fail, but the failure is never
                 // seen.)
-                self.path = PathBuf::new();
+                self.path = PathBuf::new().into_boxed_path();
                 mem::forget(self);
                 Ok(())
             }
@@ -293,7 +293,7 @@ impl TempPath {
                 // Don't drop `self`. We don't want to try deleting the old
                 // temporary file path. (It'll fail, but the failure is never
                 // seen.)
-                self.path = PathBuf::new();
+                self.path = PathBuf::new().into_boxed_path();
                 mem::forget(self);
                 Ok(())
             }
@@ -341,9 +341,9 @@ impl TempPath {
                 // Don't drop `self`. We don't want to try deleting the old
                 // temporary file path. (It'll fail, but the failure is never
                 // seen.)
-                let path = mem::replace(&mut self.path, PathBuf::new());
+                let path = mem::replace(&mut self.path, PathBuf::new().into_boxed_path());
                 mem::forget(self);
-                Ok(path)
+                Ok(path.into())
             }
             Err(e) => Err(PathPersistError {
                 error: e,
@@ -953,7 +953,9 @@ pub(crate) fn create_named(
     imp::create_named(&path, open_options)
         .with_err_path(|| path.clone())
         .map(|file| NamedTempFile {
-            path: TempPath { path },
+            path: TempPath {
+                path: path.into_boxed_path(),
+            },
             file,
         })
 }


### PR DESCRIPTION
 - Reduce size of `TempDir` and `TempPath` by using `Box<Path>` instead of `PathBuf`, since neither `TempDir` nor `TempPath` uses any function specific to `PathBuf` rather than deallocating them.
   
   For `TempDir::into_path` and `TempPath::into_path`, it is converted back into `PathBuf` with zero cost.
 - Reduce size of `TempDir` by removing use of `Option` and uses `mem::forget` and `mem::ManuallyDrop` to avoid calling `Drop::drop`, and use set field `TempDir::path` to an empty `Box`: `PathBuf::new().into_boxed_path()` to deallocate the heap memory.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>