### PR TITLE
Expose `SpooledInner` and add a `into_inner()`.

### DIFF
--- a/src/spooled.rs
+++ b/src/spooled.rs
@@ -2,8 +2,9 @@ use crate::file::tempfile;
 use std::fs::File;
 use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
 
+/// A wrapper for the two states of a `SpooledTempFile`.
 #[derive(Debug)]
-enum SpooledInner {
+pub enum SpooledInner {
     InMemory(Cursor<Vec<u8>>),
     OnDisk(File),
 }
@@ -103,6 +104,11 @@ impl SpooledTempFile {
             }
             SpooledInner::OnDisk(ref mut file) => file.set_len(size),
         }
+    }
+
+    /// Consumes and returns the inner `SpooledInner` type.
+    pub fn into_inner(self) -> SpooledInner {
+        self.inner
     }
 }
 


### PR DESCRIPTION
Heya! Really appreciate this library - using it for something and wound up with a case where I needed to extract the underlying storage on a `SpooledTempFile`.

In my case, once I've finished writing it, I need to pass it off to an async runtime to work with. Rather than deal with implementing `AsyncRead`/`AsyncWrite` on `SpooledTempFile`, I found it easier to simply pull out the underlying type and use the general `From`/`Into` conversion methods to get to an async file/cursor.

This effectively sidesteps dragging a bunch of async-related crates into this while still enabling a path towards bridging them. Something you'd be open to merging?