### PR TITLE
replace rand with fastrand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ description = "A library for managing temporary files and directories."
 
 [dependencies]
 cfg-if = "1"
-rand = { version = "0.8", features = ["small_rng", "getrandom"], default_features = false }
+fastrand = "1.2.3"
 remove_dir_all = "0.5"
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dependencies]

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,11 +8,10 @@ use crate::error::IoResultExt;
 fn tmpname(prefix: &OsStr, suffix: &OsStr, rand_len: usize) -> OsString {
     let mut buf = OsString::with_capacity(prefix.len() + suffix.len() + rand_len);
     buf.push(prefix);
-    buf.push(
-        repeat_with(fastrand::alphanumeric)
-            .take(rand_len)
-            .collect::<String>(),
-    );
+    let mut char_buf = [0u8; 4];
+    for c in repeat_with(fastrand::alphanumeric).take(rand_len) {
+        buf.push(c.encode_utf8(&mut char_buf));
+    }
     buf.push(suffix);
     buf
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,32 +1,18 @@
-use rand::{self, Rng, SeedableRng};
-use rand::{distributions::Alphanumeric, rngs::SmallRng};
+use fastrand;
 use std::ffi::{OsStr, OsString};
-use std::thread_local;
-use std::{
-    cell::UnsafeCell,
-    path::{Path, PathBuf},
-};
-use std::{io, str};
+use std::path::{Path, PathBuf};
+use std::{io, iter::repeat_with};
 
 use crate::error::IoResultExt;
-
-thread_local! {
-    static THREAD_RNG: UnsafeCell<SmallRng> = UnsafeCell::new(SmallRng::from_entropy());
-}
 
 fn tmpname(prefix: &OsStr, suffix: &OsStr, rand_len: usize) -> OsString {
     let mut buf = OsString::with_capacity(prefix.len() + suffix.len() + rand_len);
     buf.push(prefix);
-
-    // Push each character in one-by-one. Unfortunately, this is the only
-    // safe(ish) simple way to do this without allocating a temporary
-    // String/Vec.
-    THREAD_RNG.with(|rng| unsafe {
-        (&mut *rng.get())
-            .sample_iter(&Alphanumeric)
+    buf.push(
+        repeat_with(fastrand::alphanumeric)
             .take(rand_len)
-            .for_each(|b| buf.push(str::from_utf8_unchecked(&[b as u8])))
-    });
+            .collect::<String>(),
+    );
     buf.push(suffix);
     buf
 }


### PR DESCRIPTION
Re-opens #118.

At the time the PR was submitted, fastrand was new. But it's been a year now since we switched to
SmallRng and it's still going strong.

While this will _slightly_ increase the build size for crates already depending on rand, fastrand is
really small and has no direct dependencies.

Security: Neither Go nor Python's tempfile name generator use cryptographic randomness, so I'm feeling pretty comfortable sticking with non-cryptographic randomness here.