### PR TITLE
feat: Add TempDir::new_at

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -264,6 +264,40 @@ impl TempDir {
         Builder::new().tempdir_in(dir)
     }
 
+    /// Attempts to make a temporary directory at the specified `path`.
+    /// The directory and everything inside it will be automatically
+    /// deleted once the returned `TempDir` is destroyed.
+    ///
+    /// # Errors
+    ///
+    /// If the directory can not be created, `Err` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fs::{self, File};
+    /// use std::io::Write;
+    /// use tempfile::TempDir;
+    ///
+    /// # use std::io;
+    /// # fn run() -> Result<(), io::Error> {
+    /// // Create a directory inside of the current directory
+    /// let tmp_dir = TempDir::new_at("./temp_dir")?;
+    /// let file_path = tmp_dir.path().join("my-temporary-note.txt");
+    /// let mut tmp_file = File::create(file_path)?;
+    /// writeln!(tmp_file, "Brian was here. Briefly.")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_at<P: AsRef<Path>>(path: P) -> io::Result<TempDir> {
+        let path = path.as_ref().to_owned();
+        fs::create_dir(&path)
+            .with_err_path(|| &path)
+            .map(|_| TempDir {
+                path: path.into_boxed_path(),
+            })
+    }
+
     /// Accesses the [`Path`] to the temporary directory.
     ///
     /// [`Path`]: http://doc.rust-lang.org/std/path/struct.Path.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ pub use crate::file::{
     tempfile, tempfile_in, NamedTempFile, PathPersistError, PersistError, TempPath,
 };
 pub use crate::spooled::{spooled_tempfile, SpooledTempFile};
+pub use crate::util::tmpname;
 
 /// Create a new temporary file or directory with custom parameters.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,9 @@ use std::{io, iter::repeat_with};
 
 use crate::error::IoResultExt;
 
-fn tmpname(prefix: &OsStr, suffix: &OsStr, rand_len: usize) -> OsString {
+// Hide this function in the docs as it's only exposed for usage in integration tests.
+#[doc(hidden)]
+pub fn tmpname(prefix: &OsStr, suffix: &OsStr, rand_len: usize) -> OsString {
     let mut buf = OsString::with_capacity(prefix.len() + suffix.len() + rand_len);
     buf.push(prefix);
     let mut char_buf = [0u8; 4];

--- a/tests/tempdir.rs
+++ b/tests/tempdir.rs
@@ -11,11 +11,13 @@
 #![deny(rust_2018_idioms)]
 
 use std::env;
+use std::ffi::OsStr;
 use std::fs;
 use std::path::Path;
 use std::sync::mpsc::channel;
 use std::thread;
 
+use tempfile::tmpname;
 use tempfile::{Builder, TempDir};
 
 macro_rules! t {
@@ -60,6 +62,18 @@ fn test_customnamed() {
         .tempdir()
         .unwrap();
     let name = tmpfile.path().file_name().unwrap().to_str().unwrap();
+    assert!(name.starts_with("prefix"));
+    assert!(name.ends_with("suffix"));
+    assert_eq!(name.len(), 24);
+}
+
+#[test]
+fn test_custom_named_dir_at() {
+    let dirname = tmpname(OsStr::new("prefix"), OsStr::new("suffix"), 12);
+    let path = env::temp_dir().join(dirname);
+    let tmpdir = TempDir::new_at(path).unwrap();
+
+    let name = tmpdir.path().file_name().unwrap().to_str().unwrap();
     assert!(name.starts_with("prefix"));
     assert!(name.ends_with("suffix"));
     assert_eq!(name.len(), 24);


### PR DESCRIPTION
This PR adds the possibility to initialize temporary directories at a very specific path without any randomization.

While writing tests for it, I decided to use your `tmpname` function to prevent any namespace clashes during testing.
However, to do so, I had to publicly expose it. To prevent any usage by your users, I simply hid it in the documentation.
