### PR TITLE
Add NamedTempFile<F>, Builder::{make,make_in}, and NamedTempFile::from_parts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
   "Steven Allen <steven@stebalien.com>",
   "The Rust Project Developers",
   "Ashley Mannix <ashleymannix@live.com.au>",
-  "Jason White <jasonaw0@gmail.com>",
+  "Jason White <me@jasonwhite.io>",
 ]
 documentation = "https://docs.rs/tempfile"
 edition = "2018"

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,13 @@
+3.4.0 (WIP)
+=====
+
+Features:
+
+ * Add `Builder::make` and `Builder::make_in` for generalized temp file
+   creation.
+ * Add `NamedTempFile::from_parts` to complement `NamedTempFile::into_parts`.
+ * Add generic parameter to `NamedTempFile` to support wrapping non-File types.
+
 3.3.0
 =====
 

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -858,6 +858,14 @@ impl<F> NamedTempFile<F> {
     pub fn into_parts(self) -> (F, TempPath) {
         (self.file, self.path)
     }
+
+    /// Creates a `NamedTempFile` from its constituent parts.
+    ///
+    /// This can be used with [`NamedTempFile::into_parts`] to reconstruct the
+    /// `NamedTempFile`.
+    pub fn from_parts(file: F, path: TempPath) -> Self {
+        Self { file, path }
+    }
 }
 
 impl NamedTempFile<File> {


### PR DESCRIPTION
There are two main parts to this PR. Unfortunately GitHub doesn't really have the ability to make PRs depend on each other. Let me know if you want this split up into separate PRs.

Fixes #175

## `NamedTempFile<F = File>`

This adds a generic parameter to `NamedTempFile`. This enables using it with non-File types, such as:
 - `std::os::unix::net::UnixListener`,
 - `tokio::net::UnixListener`, or
 - `tokio::fs::File`

This should be a backwards compatible change. To do this, some `File`-specific stuff is only implemented for `NamedTempFile<File>`.

## `Builder::{make,make_in}`

This enables the user to leverage the file-path building part of the library while providing their own custom file creation callback. This is useful for creating UNIX domain sockets.

It was mentioned in #175 to provide a helper for creating sockets, but since UNIX domain sockets are only on UNIX, I believe it would be the only platform-dependent function. Thus, I held off on making that change. Happy to reconsider this though.

Note that `NamedTempFile::from_parts` was added to implement `Builder::make_in`. This could be made a private function, but it seems useful in the public API as well.