### PR TITLE
Add `#[must_use]` to various functions

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -292,6 +292,7 @@ impl TempDir {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn path(&self) -> &path::Path {
         self.path.as_ref()
     }
@@ -323,6 +324,7 @@ impl TempDir {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn into_path(self) -> PathBuf {
         // Prevent the Drop impl from being called.
         let mut this = mem::ManuallyDrop::new(self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,7 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }

--- a/src/spooled.rs
+++ b/src/spooled.rs
@@ -64,6 +64,7 @@ pub fn spooled_tempfile(max_size: usize) -> SpooledTempFile {
 }
 
 impl SpooledTempFile {
+    #[must_use]
     pub fn new(max_size: usize) -> SpooledTempFile {
         SpooledTempFile {
             max_size: max_size,
@@ -72,6 +73,7 @@ impl SpooledTempFile {
     }
 
     /// Returns true if the file has been rolled over to disk.
+    #[must_use]
     pub fn is_rolled(&self) -> bool {
         match self.inner {
             SpooledData::InMemory(_) => false,
@@ -107,6 +109,7 @@ impl SpooledTempFile {
     }
 
     /// Consumes and returns the inner `SpooledData` type.
+    #[must_use]
     pub fn into_inner(self) -> SpooledData {
         self.inner
     }


### PR DESCRIPTION
Based on encountering some code that called `TempDir::path` and ignored
the result.
