### PR TITLE
doc clarify statics may leak

### DIFF
--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -467,17 +467,19 @@ impl AsRef<OsStr> for TempPath {
 /// # Resource Leaking
 ///
 /// If the program exits before the `NamedTempFile` destructor is
-/// run, such as via [`std::process::exit()`], by segfaulting, or by
-/// receiving a signal like `SIGINT`, then the temporary file
-/// will not be deleted.
+/// run then the temporary file will not be deleted. This can happen
+/// if the process exits using [`std::process::exit()`], a segfault occurs,
+/// receiving an interrupt signal like `SIGINT` that is not handled, or by using
+/// a statically declared `NamedTempFile` instance (like with [`lazy_static`]).
 ///
-/// Use the [`tempfile()`] function unless you absolutely need a named file.
+/// Use the [`tempfile()`] function unless you need a named file or a file with a path.
 ///
 /// [`tempfile()`]: fn.tempfile.html
 /// [`NamedTempFile::new()`]: #method.new
 /// [`NamedTempFile::new_in()`]: #method.new_in
 /// [`std::env::temp_dir()`]: https://doc.rust-lang.org/std/env/fn.temp_dir.html
 /// [`std::process::exit()`]: http://doc.rust-lang.org/std/process/fn.exit.html
+/// [`lazy_static`]: https://github.com/rust-lang-nursery/lazy-static.rs/issues/62
 pub struct NamedTempFile<F = File> {
     path: TempPath,
     file: F,

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -467,7 +467,7 @@ impl AsRef<OsStr> for TempPath {
 /// # Resource Leaking
 ///
 /// If the program exits before the `NamedTempFile` destructor is
-/// run then the temporary file will not be deleted. This can happen
+/// run, the temporary file will not be deleted. This can happen
 /// if the process exits using [`std::process::exit()`], a segfault occurs,
 /// receiving an interrupt signal like `SIGINT` that is not handled, or by using
 /// a statically declared `NamedTempFile` instance (like with [`lazy_static`]).

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -472,7 +472,7 @@ impl AsRef<OsStr> for TempPath {
 /// receiving an interrupt signal like `SIGINT` that is not handled, or by using
 /// a statically declared `NamedTempFile` instance (like with [`lazy_static`]).
 ///
-/// Use the [`tempfile()`] function unless you need a named file or a file with a path.
+/// Use the [`tempfile()`] function unless you need a named file path.
 ///
 /// [`tempfile()`]: fn.tempfile.html
 /// [`NamedTempFile::new()`]: #method.new

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,12 @@
 //!
 //! ## Resource Leaking
 //!
-//! `tempfile` will (almost) never fail to cleanup temporary resources, but `TempDir` and `NamedTempFile` will if
-//! their destructors don't run. This is because `tempfile` relies on the OS to cleanup the
-//! underlying file, while `TempDir` and `NamedTempFile` rely on their destructors to do so.
+//! `tempfile` will (almost) never fail to cleanup temporary resources. However `TempDir` and `NamedTempFile` will
+//! fail if their destructors don't run. This is because `tempfile` relies on the OS to cleanup the
+//! underlying file, while `TempDir` and `NamedTempFile` rely on rust destructors to do so.
+//! Destructors may fail to run if the process exits through an unhandled signal interrupt (like `SIGINT`),
+//! or if the instance is declared statically (like with [`lazy_static`]), among other possible
+//! reasons.
 //!
 //! ## Security
 //!
@@ -152,6 +155,7 @@
 //! [`TempDir`]: struct.TempDir.html
 //! [`NamedTempFile`]: struct.NamedTempFile.html
 //! [`std::env::temp_dir()`]: https://doc.rust-lang.org/std/env/fn.temp_dir.html
+//! [`lazy_static`]: https://github.com/rust-lang-nursery/lazy-static.rs/issues/62
 
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",


### PR DESCRIPTION
documentation notes static declared instances may leak (like with
lazy_static). Links to underlying reason
https://github.com/rust-lang-nursery/lazy-static.rs/issues/62

Issue #183