### PR TITLE
Revert "Merge pull request #166 from sunfishcode/main"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         rust-version:
           - nightly
-          - "1.48"
+          - "1.40"
         os:
           - ubuntu-latest
           - windows-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ fastrand = "1.6.0"
 remove_dir_all = "0.5"
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
-rustix = { version = "0.35.6", features = ["fs"] }
+libc = "0.2.27"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.36"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ patterns and surprisingly difficult to implement securely).
 Usage
 -----
 
-Minimum required Rust version: 1.48.0
+Minimum required Rust version: 1.40.0
 
 Add this to your `Cargo.toml`:
 

--- a/src/file/imp/unix.rs
+++ b/src/file/imp/unix.rs
@@ -1,11 +1,13 @@
 use std::env;
-use std::ffi::OsStr;
+use std::ffi::{CString, OsStr};
 use std::fs::{self, File, OpenOptions};
 use std::io;
 cfg_if::cfg_if! {
     if #[cfg(not(target_os = "wasi"))] {
+        use std::os::unix::ffi::OsStrExt;
         use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
     } else {
+        use std::os::wasi::ffi::OsStrExt;
         #[cfg(feature = "nightly")]
         use std::os::wasi::fs::MetadataExt;
     }
@@ -14,7 +16,29 @@ use crate::util;
 use std::path::Path;
 
 #[cfg(not(target_os = "redox"))]
-use rustix::fs::{cwd, linkat, renameat, unlinkat, AtFlags};
+use libc::{c_char, c_int, link, rename, unlink};
+
+#[cfg(not(target_os = "redox"))]
+#[inline(always)]
+pub fn cvt_err(result: c_int) -> io::Result<c_int> {
+    if result == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(result)
+    }
+}
+
+#[cfg(target_os = "redox")]
+#[inline(always)]
+pub fn cvt_err(result: Result<usize, syscall::Error>) -> io::Result<usize> {
+    result.map_err(|err| io::Error::from_raw_os_error(err.errno))
+}
+
+// Stolen from std.
+pub fn cstr(path: &Path) -> io::Result<CString> {
+    CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contained a null"))
+}
 
 pub fn create_named(path: &Path, open_options: &mut OpenOptions) -> io::Result<File> {
     open_options.read(true).write(true).create_new(true);
@@ -46,18 +70,16 @@ fn create_unlinked(path: &Path) -> io::Result<File> {
 
 #[cfg(target_os = "linux")]
 pub fn create(dir: &Path) -> io::Result<File> {
-    use rustix::{fs::OFlags, io::Errno};
+    use libc::{EISDIR, ENOENT, EOPNOTSUPP, O_TMPFILE};
     OpenOptions::new()
         .read(true)
         .write(true)
-        .custom_flags(OFlags::TMPFILE.bits() as i32) // do not mix with `create_new(true)`
+        .custom_flags(O_TMPFILE) // do not mix with `create_new(true)`
         .open(dir)
         .or_else(|e| {
-            match Errno::from_io_error(&e) {
+            match e.raw_os_error() {
                 // These are the three "not supported" error codes for O_TMPFILE.
-                Some(Errno::OPNOTSUPP) | Some(Errno::ISDIR) | Some(Errno::NOENT) => {
-                    create_unix(dir)
-                }
+                Some(EOPNOTSUPP) | Some(EISDIR) | Some(ENOENT) => create_unix(dir),
                 _ => Err(e),
             }
         })
@@ -102,36 +124,25 @@ pub fn reopen(_file: &File, _path: &Path) -> io::Result<File> {
 
 #[cfg(not(target_os = "redox"))]
 pub fn persist(old_path: &Path, new_path: &Path, overwrite: bool) -> io::Result<()> {
-    if overwrite {
-        renameat(cwd(), old_path, cwd(), new_path)?;
-    } else {
-        // On Linux, use `renameat_with` to avoid overwriting an existing name,
-        // if the kernel and the filesystem support it.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
-        {
-            use rustix::fs::{renameat_with, RenameFlags};
-            use rustix::io::Errno;
-            use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
-
-            static NOSYS: AtomicBool = AtomicBool::new(false);
-            if !NOSYS.load(Relaxed) {
-                match renameat_with(cwd(), old_path, cwd(), new_path, RenameFlags::NOREPLACE) {
-                    Ok(()) => return Ok(()),
-                    Err(Errno::NOSYS) => NOSYS.store(true, Relaxed),
-                    Err(Errno::INVAL) => {}
-                    Err(e) => return Err(e.into()),
-                }
-            }
+    unsafe {
+        let old_path = cstr(old_path)?;
+        let new_path = cstr(new_path)?;
+        if overwrite {
+            cvt_err(rename(
+                old_path.as_ptr() as *const c_char,
+                new_path.as_ptr() as *const c_char,
+            ))?;
+        } else {
+            cvt_err(link(
+                old_path.as_ptr() as *const c_char,
+                new_path.as_ptr() as *const c_char,
+            ))?;
+            // Ignore unlink errors. Can we do better?
+            // On recent linux, we can use renameat2 to do this atomically.
+            let _ = unlink(old_path.as_ptr() as *const c_char);
         }
-
-        // Otherwise use `linkat` to create the new filesystem name, which
-        // will fail if the name already exists, and then `unlinkat` to remove
-        // the old name.
-        linkat(cwd(), old_path, cwd(), new_path, AtFlags::empty())?;
-        // Ignore unlink errors. Can we do better?
-        let _ = unlinkat(cwd(), old_path, AtFlags::empty());
+        Ok(())
     }
-    Ok(())
 }
 
 #[cfg(target_os = "redox")]


### PR DESCRIPTION
Unfortunately, this uses "raw" syscalls by default, which is too much of a breaking change for users that expect to be able to override libc (I only noticed this when writing the changelog, unfortunately).

We'd be able to use rustix if it made "linux-raw" an enabled-by-default feature:

1. Make "linux-raw" a feature, instead of "use-libc".
2. Set `default = ["std", "linux_raw"]`.

Unfortunately, that would be a breaking change.

Alternatively, the standard library would have to switch to rustix by default.