### PR TITLE
fix: don't claim 'too many temporary files exist' if a file already existed, once.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -34,10 +34,10 @@ where
     for _ in 0..num_retries {
         let path = base.join(tmpname(prefix, suffix, random_len));
         return match f(path) {
-            Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists && num_retries > 1 => continue,
             // AddrInUse can happen if we're creating a UNIX domain socket and
             // the path already exists.
-            Err(ref e) if e.kind() == io::ErrorKind::AddrInUse => continue,
+            Err(ref e) if e.kind() == io::ErrorKind::AddrInUse && num_retries > 1 => continue,
             res => res,
         };
     }


### PR DESCRIPTION
Previously when creating a temporary file without any random characters
in it, a loop would effectively run once and fail with the conclusion
that a file could not be created because too many temporary files exist
(2_147_483_648).

Now it will return the original failure, which typically is that the
file with the given name already existed.

This can more easily happen on case-insentiive file systems, and the
correct error message helps understanding what went wrong.

See https://github.com/Byron/gitoxide/issues/595 for reference.
