### PR TITLE
Update to rustix 0.36.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ fastrand = "1.6.0"
 remove_dir_all = "0.5"
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
-rustix = { version = "0.35.6", features = ["fs"] }
+rustix = { version = "0.36.0", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.42"


### PR DESCRIPTION
The main change in this version is to switch to using the I/O safety types and traits from std, on Rust versions where they're available.