### PR TITLE
Add Builder usage example for tempdir with a chosen prefix under a chosen folder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,16 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// Create a temporary directory with a chosen prefix under a chosen folder:
+    ///
+    /// ```
+    /// use tempfile::Builder;
+    ///
+    /// let dir = Builder::new()
+    ///     .prefix("my-temporary-dir")
+    ///     .tempdir_in("folder-with-tempdirs")?;
+    /// ```
     #[must_use]
     pub fn new() -> Self {
         Self::default()


### PR DESCRIPTION
 This will be helpful for people migrating from tempdir
 (TempDir::new_in), which accepts a prefix and a destination folder as
 parameters.

 Developers are suggested migrating to tempfile through RUSTSEC-2018-0017.

 The example is quite simple, but it's especially helpful for people not
 too familiar with Builders, which could be coming from tempdir which has a
 method that accomplishes this.
 
 Example of migration from tempdir to tempfile:
 https://github.com/kinnison/git-testament/commit/1538fa0dfdd927bb93ac837031ab2cf3b5ec2b2e