### PR TITLE
Upgrade remove_dir_all to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ description = "A library for managing temporary files and directories."
 [dependencies]
 cfg-if = "1"
 fastrand = "1.6.0"
-remove_dir_all = "0.5"
+remove_dir_all = "0.8"
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
 rustix = { version = "0.36.0", features = ["fs"] }


### PR DESCRIPTION
This removes the `winapi` dependency from `remove_dir_all`