### PR TITLE
ci: disable fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
   build_and_test:
     name: OS Test
     strategy:
+      fail-fast: false
       matrix:
         rust-version:
           - nightly


### PR DESCRIPTION
Macos 1.48.0 is failing right now (https://github.com/rust-lang/rust/issues/107252).