### PR TITLE
ci: replace unmaintained actions-rs/cargo actions in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,9 @@ jobs:
           toolchain: ${{ matrix.rust-version }}
           default: true
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
   wasi:
     name: WASI Test Build
     runs-on: ubuntu-latest
@@ -47,15 +43,9 @@ jobs:
           toolchain: nightly
           default: true
       - name: Install Cargo WASI
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-wasi
+        run: cargo install cargo-wasi
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: wasi
-          args: build --features nightly
+        run: cargo wasi build --features nightly
   wasm:
     name: WASM Test Build
     runs-on: ubuntu-latest
@@ -69,7 +59,4 @@ jobs:
           toolchain: stable
           default: true
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target wasm32-unknown-unknown
+        run: cargo build --target wasm32-unknown-unknown


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/Stebalien/tempfile/actions/runs/4271041404:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of some of those warnings the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.