### PR TITLE
Specify the MSRV in the Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 ]
 documentation = "https://docs.rs/tempfile"
 edition = "2018"
+rust-version = "1.48"
 homepage = "https://stebalien.com/projects/tempfile-rs/"
 keywords = ["tempfile", "tmpfile", "filesystem"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
It's good to have the MSRV available in a standarized, machine readable format.