### PR TITLE
Forward default NamedTempFile methods

### DIFF
--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -916,11 +916,57 @@ impl<F: Read> Read for NamedTempFile<F> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.as_file_mut().read(buf).with_err_path(|| self.path())
     }
+
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        self.as_file_mut()
+            .read_vectored(bufs)
+            .with_err_path(|| self.path())
+    }
+
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.as_file_mut()
+            .read_to_end(buf)
+            .with_err_path(|| self.path())
+    }
+
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.as_file_mut()
+            .read_to_string(buf)
+            .with_err_path(|| self.path())
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.as_file_mut()
+            .read_exact(buf)
+            .with_err_path(|| self.path())
+    }
 }
 
 impl Read for &NamedTempFile<File> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.as_file().read(buf).with_err_path(|| self.path())
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        self.as_file()
+            .read_vectored(bufs)
+            .with_err_path(|| self.path())
+    }
+
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.as_file()
+            .read_to_end(buf)
+            .with_err_path(|| self.path())
+    }
+
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.as_file()
+            .read_to_string(buf)
+            .with_err_path(|| self.path())
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.as_file().read_exact(buf).with_err_path(|| self.path())
     }
 }
 
@@ -932,6 +978,24 @@ impl<F: Write> Write for NamedTempFile<F> {
     fn flush(&mut self) -> io::Result<()> {
         self.as_file_mut().flush().with_err_path(|| self.path())
     }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.as_file_mut()
+            .write_vectored(bufs)
+            .with_err_path(|| self.path())
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.as_file_mut()
+            .write_all(buf)
+            .with_err_path(|| self.path())
+    }
+
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.as_file_mut()
+            .write_fmt(fmt)
+            .with_err_path(|| self.path())
+    }
 }
 
 impl Write for &NamedTempFile<File> {
@@ -941,6 +1005,20 @@ impl Write for &NamedTempFile<File> {
     #[inline]
     fn flush(&mut self) -> io::Result<()> {
         self.as_file().flush().with_err_path(|| self.path())
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.as_file()
+            .write_vectored(bufs)
+            .with_err_path(|| self.path())
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.as_file().write_all(buf).with_err_path(|| self.path())
+    }
+
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.as_file().write_fmt(fmt).with_err_path(|| self.path())
     }
 }
 


### PR DESCRIPTION
Instead of using the default method implementations, forward them to the underlying file. This allows the user to, e.g., take advantage of vectorized IO.