### PR TITLE
feat: implement AsFd/AsHandle to mirror the AsRaw* variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,8 @@ redox_syscall = "0.3"
 [dev-dependencies]
 doc-comment = "0.3"
 
+[build-dependencies]
+autocfg = "1"
+
 [features]
 nightly = []

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let ac = autocfg::new();
+
+    #[cfg(unix)]
+    ac.emit_trait_cfg("std::os::fd::AsFd", "fd");
+    #[cfg(windows)]
+    ac.emit_trait_cfg("std::os::windows::io::AsHandle", "fd");
+
+    autocfg::rerun_path("build.rs");
+}

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -1035,19 +1035,19 @@ impl Seek for &NamedTempFile<File> {
 }
 
 #[cfg(all(fd, unix))]
-impl<F: std::os::fd::AsFd> std::os::fd::AsFd for NamedTempFile<F> {
-    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
+impl<F: std::os::unix::io::AsFd> std::os::unix::io::AsFd for NamedTempFile<F> {
+    fn as_fd(&self) -> std::os::unix::io::BorrowedFd<'_> {
         self.as_file().as_fd()
     }
 }
 
 #[cfg(unix)]
-impl<F> std::os::fd::AsRawFd for NamedTempFile<F>
+impl<F> std::os::unix::io::AsRawFd for NamedTempFile<F>
 where
-    F: std::os::fd::AsRawFd,
+    F: std::os::unix::io::AsRawFd,
 {
     #[inline]
-    fn as_raw_fd(&self) -> std::os::fd::RawFd {
+    fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
         self.as_file().as_raw_fd()
     }
 }

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -1034,7 +1034,7 @@ impl Seek for &NamedTempFile<File> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(fd, unix))]
 impl<F: std::os::fd::AsFd> std::os::fd::AsFd for NamedTempFile<F> {
     fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
         self.as_file().as_fd()
@@ -1052,7 +1052,7 @@ where
     }
 }
 
-#[cfg(windows)]
+#[cfg(all(fd, windows))]
 impl<F> std::os::windows::io::AsHandle for NamedTempFile<F>
 where
     F: std::os::windows::io::AsHandle,

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -1035,13 +1035,31 @@ impl Seek for &NamedTempFile<File> {
 }
 
 #[cfg(unix)]
-impl<F> std::os::unix::io::AsRawFd for NamedTempFile<F>
+impl<F: std::os::fd::AsFd> std::os::fd::AsFd for NamedTempFile<F> {
+    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
+        self.as_file().as_fd()
+    }
+}
+
+#[cfg(unix)]
+impl<F> std::os::fd::AsRawFd for NamedTempFile<F>
 where
-    F: std::os::unix::io::AsRawFd,
+    F: std::os::fd::AsRawFd,
 {
     #[inline]
-    fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
         self.as_file().as_raw_fd()
+    }
+}
+
+#[cfg(windows)]
+impl<F> std::os::windows::io::AsHandle for NamedTempFile<F>
+where
+    F: std::os::windows::io::AsHandle,
+{
+    #[inline]
+    fn as_handle(&self) -> std::os::windows::io::BorrowedHandle<'_> {
+        self.as_file().as_handle()
     }
 }
 


### PR DESCRIPTION
We don't implement the "into" variants as that'll drop and delete the temporary file.