### PR TITLE
fix(docs): Change `dir` and `file` variable names ...

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -45,16 +45,16 @@ use crate::Builder;
 /// # }
 /// # fn run() -> Result<(), io::Error> {
 /// // Create a directory inside of `std::env::temp_dir()`
-/// let dir = tempdir()?;
+/// let tmp_dir = tempdir()?;
 ///
-/// let file_path = dir.path().join("my-temporary-note.txt");
-/// let mut file = File::create(file_path)?;
-/// writeln!(file, "Brian was here. Briefly.")?;
+/// let file_path = tmp_dir.path().join("my-temporary-note.txt");
+/// let mut tmp_file = File::create(file_path)?;
+/// writeln!(tmp_file, "Brian was here. Briefly.")?;
 ///
 /// // `tmp_dir` goes out of scope, the directory as well as
 /// // `tmp_file` will be deleted here.
-/// drop(file);
-/// dir.close()?;
+/// drop(tmp_file);
+/// tmp_dir.close()?;
 /// # Ok(())
 /// # }
 /// ```
@@ -94,16 +94,16 @@ pub fn tempdir() -> io::Result<TempDir> {
 /// # }
 /// # fn run() -> Result<(), io::Error> {
 /// // Create a directory inside of the current directory.
-/// let dir = tempdir_in(".")?;
+/// let tmp_dir = tempdir_in(".")?;
 ///
-/// let file_path = dir.path().join("my-temporary-note.txt");
-/// let mut file = File::create(file_path)?;
-/// writeln!(file, "Brian was here. Briefly.")?;
+/// let file_path = tmp_dir.path().join("my-temporary-note.txt");
+/// let mut tmp_file = File::create(file_path)?;
+/// writeln!(tmp_file, "Brian was here. Briefly.")?;
 ///
 /// // `tmp_dir` goes out of scope, the directory as well as
 /// // `tmp_file` will be deleted here.
-/// drop(file);
-/// dir.close()?;
+/// drop(tmp_file);
+/// tmp_dir.close()?;
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
# fix(docs): Change `dir` and `file` variable names in `tempdir` and `tempdir_in` documentation 

to match existing comments and rest of module

## Problem statement

The documentation for [tempdir](https://docs.rs/tempfile/latest/tempfile/fn.tempdir.html) and [tempdir_in](https://docs.rs/tempfile/latest/tempfile/fn.tempdir_in.html) use variables `dir` and `file` but refer to them as `tmp_dir` and `tmp_file` in code comments.

## Discussion

The comments could be changed to refer to `dir` and `file`. However, the rest of the module uses `tmp_dir` and `tmp_file`.

## PR changes

The variable names were changed. 

This way, they match the comments referring to these variables as well as the rest of the module documentation.

## Tests

Existing doctests succeed.

```
test src/dir.rs - dir::tempdir (line 36) ... ok
test src/dir.rs - dir::tempdir_in (line 85) ... ok
```