### PR TITLE
Derive Serde + Standard traits + Implement `Display`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempfile"
-version = "3.5.0"
+version = "3.5.1"
 authors = [
   "Steven Allen <steven@stebalien.com>",
   "The Rust Project Developers",
@@ -19,6 +19,7 @@ description = "A library for managing temporary files and directories."
 [dependencies]
 cfg-if = "1"
 fastrand = "1.6.0"
+serde = { version = "1.0.163",  optional = true, features = ["derive"] }
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
 rustix = { version = "0.37.11", features = ["fs"] }
@@ -41,3 +42,4 @@ autocfg = "1"
 
 [features]
 nightly = []
+serde = ["dep:serde"]

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -13,6 +13,9 @@ use std::mem;
 use std::path::{self, Path, PathBuf};
 use std::{fmt, fs, io};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::error::IoResultExt;
 use crate::Builder;
 
@@ -192,6 +195,8 @@ pub fn tempdir_in<P: AsRef<Path>>(dir: P) -> io::Result<TempDir> {
 /// [`std::env::temp_dir()`]: https://doc.rust-lang.org/std/env/fn.temp_dir.html
 /// [`std::fs`]: http://doc.rust-lang.org/std/fs/index.html
 /// [`std::process::exit()`]: http://doc.rust-lang.org/std/process/fn.exit.html
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)] // Debug and Display are implemented manually
 pub struct TempDir {
     path: Box<Path>,
 }
@@ -405,6 +410,12 @@ impl fmt::Debug for TempDir {
 impl Drop for TempDir {
     fn drop(&mut self) {
         let _ = remove_dir_all(self.path());
+    }
+}
+
+impl fmt::Display for TempDir {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.path.display())
     }
 }
 


### PR DESCRIPTION
The [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html) recommend deriving / implementing the following traits [C-COMMON-TRAITS](https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits):

```
Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Display, Default
```

`Debug` is already implemented and `Display` and `Copy` aren't derivable in this case.
So this PR derives all remaining traits, and implements `Display` for TempDir.

---

It also adds a "serde" feature ([C-SERDE](https://rust-lang.github.io/api-guidelines/interoperability.html#c-serde)), if it's enabled, Serde's `Serialize` and `Deserialize` are also derived.