### PR TITLE
feat: Allow cloning of TempDir

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -192,6 +192,7 @@ pub fn tempdir_in<P: AsRef<Path>>(dir: P) -> io::Result<TempDir> {
 /// [`std::env::temp_dir()`]: https://doc.rust-lang.org/std/env/fn.temp_dir.html
 /// [`std::fs`]: http://doc.rust-lang.org/std/fs/index.html
 /// [`std::process::exit()`]: http://doc.rust-lang.org/std/process/fn.exit.html
+#[derive(Clone)]
 pub struct TempDir {
     path: Box<Path>,
 }


### PR DESCRIPTION
This commit enables the option to clone the TempDir object, allowing multiple structures to own their own instance.

It is common for a directory to be passed among multiple structures.

For example, during integration testing, there may be a scenario where two instances of a daemon are running simultaneously and accessing the disk. In such cases, the order of dropping the directory becomes irrelevant since it will be cleaned up at the end of the test anyway.