### PR TITLE
feat: add convenience methods for creating temp files with prefixes

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::ffi::OsStr;
 use std::fs::remove_dir_all;
 use std::mem;
 use std::path::{self, Path, PathBuf};
@@ -262,6 +263,65 @@ impl TempDir {
     /// ```
     pub fn new_in<P: AsRef<Path>>(dir: P) -> io::Result<TempDir> {
         Builder::new().tempdir_in(dir)
+    }
+
+    /// Attempts to make a temporary directory with the specified prefix inside of
+    /// `env::temp_dir()`. The directory and everything inside it will be automatically
+    /// deleted once the returned `TempDir` is destroyed.
+    ///
+    /// # Errors
+    ///
+    /// If the directory can not be created, `Err` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fs::{self, File};
+    /// use std::io::Write;
+    /// use tempfile::TempDir;
+    ///
+    /// # use std::io;
+    /// # fn run() -> Result<(), io::Error> {
+    /// // Create a directory inside of the current directory
+    /// let tmp_dir = TempDir::with_prefix("foo-")?;
+    /// let tmp_name = tmp_dir.path().file_name().unwrap().to_str().unwrap();
+    /// assert!(tmp_name.starts_with("foo-"));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_prefix<S: AsRef<OsStr>>(prefix: S) -> io::Result<TempDir> {
+        Builder::new().prefix(&prefix).tempdir()
+    }
+
+    /// Attempts to make a temporary directory with the specified prefix inside
+    /// the specified directory. The directory and everything inside it will be
+    /// automatically deleted once the returned `TempDir` is destroyed.
+    ///
+    /// # Errors
+    ///
+    /// If the directory can not be created, `Err` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fs::{self, File};
+    /// use std::io::Write;
+    /// use tempfile::TempDir;
+    ///
+    /// # use std::io;
+    /// # fn run() -> Result<(), io::Error> {
+    /// // Create a directory inside of the current directory
+    /// let tmp_dir = TempDir::with_prefix_in("foo-", ".")?;
+    /// let tmp_name = tmp_dir.path().file_name().unwrap().to_str().unwrap();
+    /// assert!(tmp_name.starts_with("foo-"));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_prefix_in<S: AsRef<OsStr>, P: AsRef<Path>>(
+        prefix: S,
+        dir: P,
+    ) -> io::Result<TempDir> {
+        Builder::new().prefix(&prefix).tempdir_in(dir)
     }
 
     /// Accesses the [`Path`] to the temporary directory.

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -608,11 +608,44 @@ impl NamedTempFile<File> {
 
     /// Create a new named temporary file in the specified directory.
     ///
+    /// This is equivalent to:
+    ///
+    /// ```ignore
+    /// Builder::new().prefix(&prefix).tempfile()
+    /// ```
+    ///
     /// See [`NamedTempFile::new()`] for details.
     ///
     /// [`NamedTempFile::new()`]: #method.new
     pub fn new_in<P: AsRef<Path>>(dir: P) -> io::Result<NamedTempFile> {
         Builder::new().tempfile_in(dir)
+    }
+
+    /// Create a new named temporary file with the specified filename prefix.
+    ///
+    /// See [`NamedTempFile::new()`] for details.
+    ///
+    /// [`NamedTempFile::new()`]: #method.new
+    pub fn with_prefix<S: AsRef<OsStr>>(prefix: S) -> io::Result<NamedTempFile> {
+        Builder::new().prefix(&prefix).tempfile()
+    }
+    /// Create a new named temporary file with the specified filename prefix,
+    /// in the specified directory.
+    ///
+    /// This is equivalent to:
+    ///
+    /// ```ignore
+    /// Builder::new().prefix(&prefix).tempfile_in(directory)
+    /// ```
+    ///
+    /// See [`NamedTempFile::new()`] for details.
+    ///
+    /// [`NamedTempFile::new()`]: #method.new
+    pub fn with_prefix_in<S: AsRef<OsStr>, P: AsRef<Path>>(
+        prefix: S,
+        dir: P,
+    ) -> io::Result<NamedTempFile> {
+        Builder::new().prefix(&prefix).tempfile_in(dir)
     }
 }
 

--- a/tests/namedtempfile.rs
+++ b/tests/namedtempfile.rs
@@ -12,6 +12,13 @@ fn exists<P: AsRef<Path>>(path: P) -> bool {
 }
 
 #[test]
+fn test_prefix() {
+    let tmpfile = NamedTempFile::with_prefix("prefix").unwrap();
+    let name = tmpfile.path().file_name().unwrap().to_str().unwrap();
+    assert!(name.starts_with("prefix"));
+}
+
+#[test]
 fn test_basic() {
     let mut tmpfile = NamedTempFile::new().unwrap();
     write!(tmpfile, "abcde").unwrap();

--- a/tests/tempdir.rs
+++ b/tests/tempdir.rs
@@ -51,6 +51,12 @@ fn test_tempdir() {
     assert!(!path.exists());
 }
 
+fn test_prefix() {
+    let tmpfile = TempDir::with_prefix_in("prefix", ".").unwrap();
+    let name = tmpfile.path().file_name().unwrap().to_str().unwrap();
+    assert!(name.starts_with("prefix"));
+}
+
 fn test_customnamed() {
     let tmpfile = Builder::new()
         .prefix("prefix")
@@ -184,6 +190,7 @@ pub fn pass_as_asref_path() {
 #[test]
 fn main() {
     in_tmpdir(test_tempdir);
+    in_tmpdir(test_prefix);
     in_tmpdir(test_customnamed);
     in_tmpdir(test_rm_tempdir);
     in_tmpdir(test_rm_tempdir_close);


### PR DESCRIPTION
- `TempDir::with_prefix(prefix)`
- `TempDir::with_prefix_in(prefix, directory)`
- `TempFile::with_prefix(prefix)`
- `TempFile::with_prefix_in(prefix, directory)`

fixes #249