### PR TITLE
chore: cleanup tempdir tests

### DIFF
--- a/tests/tempdir.rs
+++ b/tests/tempdir.rs
@@ -51,7 +51,6 @@ fn test_tempdir() {
     assert!(!path.exists());
 }
 
-#[test]
 fn test_customnamed() {
     let tmpfile = Builder::new()
         .prefix("prefix")
@@ -148,72 +147,7 @@ fn test_rm_tempdir_close() {
     assert!(!path.exists());
 }
 
-// Ideally these would be in std::os but then core would need
-// to depend on std
-fn recursive_mkdir_rel() {
-    let path = Path::new("frob");
-    let cwd = env::current_dir().unwrap();
-    println!(
-        "recursive_mkdir_rel: Making: {} in cwd {} [{}]",
-        path.display(),
-        cwd.display(),
-        path.exists()
-    );
-    t!(fs::create_dir(path));
-    assert!(path.is_dir());
-    t!(fs::create_dir_all(path));
-    assert!(path.is_dir());
-}
-
-fn recursive_mkdir_dot() {
-    let dot = Path::new(".");
-    t!(fs::create_dir_all(dot));
-    let dotdot = Path::new("..");
-    t!(fs::create_dir_all(dotdot));
-}
-
-fn recursive_mkdir_rel_2() {
-    let path = Path::new("./frob/baz");
-    let cwd = env::current_dir().unwrap();
-    println!(
-        "recursive_mkdir_rel_2: Making: {} in cwd {} [{}]",
-        path.display(),
-        cwd.display(),
-        path.exists()
-    );
-    t!(fs::create_dir_all(path));
-    assert!(path.is_dir());
-    assert!(path.parent().unwrap().is_dir());
-    let path2 = Path::new("quux/blat");
-    println!(
-        "recursive_mkdir_rel_2: Making: {} in cwd {}",
-        path2.display(),
-        cwd.display()
-    );
-    t!(fs::create_dir("quux"));
-    t!(fs::create_dir_all(path2));
-    assert!(path2.is_dir());
-    assert!(path2.parent().unwrap().is_dir());
-}
-
-// Ideally this would be in core, but needs TempFile
-pub fn test_remove_dir_all_ok() {
-    let tmpdir = t!(TempDir::new());
-    let tmpdir = tmpdir.path();
-    let root = tmpdir.join("foo");
-
-    println!("making {}", root.display());
-    t!(fs::create_dir(&root));
-    t!(fs::create_dir(root.join("foo")));
-    t!(fs::create_dir(root.join("foo").join("bar")));
-    t!(fs::create_dir(root.join("foo").join("bar").join("blat")));
-    t!(fs::remove_dir_all(&root));
-    assert!(!root.exists());
-    assert!(!root.join("bar").exists());
-    assert!(!root.join("bar").join("blat").exists());
-}
-
-pub fn dont_double_panic() {
+fn dont_double_panic() {
     let r: Result<(), _> = thread::spawn(move || {
         let tmpdir = TempDir::new().unwrap();
         // Remove the temporary directory so that TempDir sees
@@ -250,12 +184,9 @@ pub fn pass_as_asref_path() {
 #[test]
 fn main() {
     in_tmpdir(test_tempdir);
+    in_tmpdir(test_customnamed);
     in_tmpdir(test_rm_tempdir);
     in_tmpdir(test_rm_tempdir_close);
-    in_tmpdir(recursive_mkdir_rel);
-    in_tmpdir(recursive_mkdir_dot);
-    in_tmpdir(recursive_mkdir_rel_2);
-    in_tmpdir(test_remove_dir_all_ok);
     in_tmpdir(dont_double_panic);
     in_tmpdir(pass_as_asref_path);
 }


### PR DESCRIPTION
We had some leftovers from when the tempdir crate was merged.