### PR TITLE
Add cargo deny config and add cargo deny job to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
 
 name: CI
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,18 @@ on:
 
 name: CI
 jobs:
+  deny:
+    name: Cargo deny
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: EmbarkStudios/cargo-deny-action@v1
+    timeout-minutes: 10
+
   build_and_test:
     name: OS Test
     strategy:

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,40 @@
+
+[advisories]
+notice = "deny"
+unmaintained = "deny"
+vulnerability = "deny"
+yanked = "deny"
+ignore = []
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "MIT",
+]
+default = "deny"
+confidence-threshold = 1.0
+unlicensed = "deny"
+
+[bans]
+allow = []
+deny = []
+multiple-versions = "deny"
+skip = [
+    # Transitive dependency of both redox_syscall and rustix (rustix has newer).
+    #
+    # Only one version of bitflags ultimately gets compiled in due to OS-based feature flags in tempfile.
+    { name = "bitflags" },
+]
+skip-tree = []
+wildcards = "deny"
+
+[sources]
+allow-git = []
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+unknown-git = "deny"
+unknown-registry = "deny"
+
+[sources.allow-org]
+github = []
+gitlab = []
+bitbucket = []


### PR DESCRIPTION
Add `cargo deny` configuration which matches status quo of the crate. Also add a job to CI to run the check.

This will cause CVEs, duplicate dependencies, unexpected licenses, and other issues to be caught during CI, before the crate is published.