### PR TITLE
chore: update rustix to 0.38.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cfg-if = "1"
 fastrand = "2.0.0"
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
-rustix = { version = "0.38", features = ["fs"] }
+rustix = { version = "0.38.21", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48"


### PR DESCRIPTION
Technically we don't need to patch this here, but this will fix any hidden bugs in downstream crates.

fixes #259