### PR TITLE
Update `windows-sys` 0.52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ fastrand = "2.0.0"
 rustix = { version = "0.38.21", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48"
+version = "0.52"
 features = [
     "Win32_Storage_FileSystem",
     "Win32_Foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cfg-if = "1"
 fastrand = "2.0.0"
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
-rustix = { version = "0.38.21", features = ["fs"] }
+rustix = { version = "0.38.26", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52"


### PR DESCRIPTION
This is the first update to the `windows-sys` crate in 8 months.  https://github.com/microsoft/windows-rs/releases/tag/0.52.0