### PR TITLE
feat: Add `Builder::permissions()` method.

### DIFF
--- a/src/dir/imp/any.rs
+++ b/src/dir/imp/any.rs
@@ -1,0 +1,19 @@
+use crate::error::IoResultExt;
+use crate::TempDir;
+use std::path::PathBuf;
+use std::{fs, io};
+
+fn not_supported<T>(msg: &str) -> io::Result<T> {
+    Err(io::Error::new(io::ErrorKind::Other, msg))
+}
+
+pub fn create(path: PathBuf, permissions: Option<&std::fs::Permissions>) -> io::Result<TempDir> {
+    if permissions.map_or(false, |p| p.readonly()) {
+        return not_supported("changing permissions is not supported on this platform");
+    }
+    fs::create_dir(&path)
+        .with_err_path(|| &path)
+        .map(|_| TempDir {
+            path: path.into_boxed_path(),
+        })
+}

--- a/src/dir/imp/mod.rs
+++ b/src/dir/imp/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use unix::*;
+
+#[cfg(not(unix))]
+mod any;
+#[cfg(not(unix))]
+pub use any::*;

--- a/src/dir/imp/unix.rs
+++ b/src/dir/imp/unix.rs
@@ -1,0 +1,21 @@
+use crate::error::IoResultExt;
+use crate::TempDir;
+use std::io;
+use std::path::PathBuf;
+
+pub fn create(path: PathBuf, permissions: Option<&std::fs::Permissions>) -> io::Result<TempDir> {
+    let mut dir_options = std::fs::DirBuilder::new();
+    #[cfg(not(target_os = "wasi"))]
+    {
+        use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+        if let Some(p) = permissions {
+            dir_options.mode(p.mode());
+        }
+    }
+    dir_options
+        .create(&path)
+        .with_err_path(|| &path)
+        .map(|_| TempDir {
+            path: path.into_boxed_path(),
+        })
+}

--- a/src/dir/mod.rs
+++ b/src/dir/mod.rs
@@ -12,7 +12,7 @@ use std::ffi::OsStr;
 use std::fs::remove_dir_all;
 use std::mem;
 use std::path::{self, Path, PathBuf};
-use std::{fmt, fs, io};
+use std::{fmt, io};
 
 use crate::error::IoResultExt;
 use crate::Builder;
@@ -468,10 +468,11 @@ impl Drop for TempDir {
     }
 }
 
-pub(crate) fn create(path: PathBuf) -> io::Result<TempDir> {
-    fs::create_dir(&path)
-        .with_err_path(|| &path)
-        .map(|_| TempDir {
-            path: path.into_boxed_path(),
-        })
+pub(crate) fn create(
+    path: PathBuf,
+    permissions: Option<&std::fs::Permissions>,
+) -> io::Result<TempDir> {
+    imp::create(path, permissions)
 }
+
+mod imp;

--- a/src/file/imp/other.rs
+++ b/src/file/imp/other.rs
@@ -9,7 +9,11 @@ fn not_supported<T>() -> io::Result<T> {
     ))
 }
 
-pub fn create_named(_path: &Path, _open_options: &mut OpenOptions) -> io::Result<File> {
+pub fn create_named(
+    _path: &Path,
+    _open_options: &mut OpenOptions,
+    _permissions: Option<&std::fs::Permissions>,
+) -> io::Result<File> {
     not_supported()
 }
 

--- a/src/file/imp/unix.rs
+++ b/src/file/imp/unix.rs
@@ -4,7 +4,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io;
 cfg_if::cfg_if! {
     if #[cfg(not(target_os = "wasi"))] {
-        use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+        use std::os::unix::fs::MetadataExt;
     } else {
         #[cfg(feature = "nightly")]
         use std::os::wasi::fs::MetadataExt;
@@ -20,14 +20,11 @@ use {
 };
 
 pub fn create_named(path: &Path, open_options: &mut OpenOptions) -> io::Result<File> {
-    open_options.read(true).write(true).create_new(true);
-
-    #[cfg(not(target_os = "wasi"))]
-    {
-        open_options.mode(0o600);
-    }
-
-    open_options.open(path)
+    open_options
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(path)
 }
 
 fn create_unlinked(path: &Path) -> io::Result<File> {
@@ -50,6 +47,7 @@ fn create_unlinked(path: &Path) -> io::Result<File> {
 #[cfg(target_os = "linux")]
 pub fn create(dir: &Path) -> io::Result<File> {
     use rustix::{fs::OFlags, io::Errno};
+    use std::os::unix::fs::OpenOptionsExt;
     OpenOptions::new()
         .read(true)
         .write(true)

--- a/src/file/imp/unix.rs
+++ b/src/file/imp/unix.rs
@@ -83,7 +83,8 @@ fn create_unix(dir: &Path) -> io::Result<File> {
         OsStr::new(".tmp"),
         OsStr::new(""),
         crate::NUM_RAND_CHARS,
-        |path| create_unlinked(&path),
+        None,
+        |path, _| create_unlinked(&path),
     )
 }
 

--- a/src/file/imp/windows.rs
+++ b/src/file/imp/windows.rs
@@ -19,11 +19,18 @@ fn to_utf16(s: &Path) -> Vec<u16> {
     s.as_os_str().encode_wide().chain(iter::once(0)).collect()
 }
 
+fn not_supported<T>(msg: &str) -> io::Result<T> {
+    Err(io::Error::new(io::ErrorKind::Other, msg))
+}
+
 pub fn create_named(
     path: &Path,
     open_options: &mut OpenOptions,
-    _permissions: Option<&std::fs::Permissions>,
+    permissions: Option<&std::fs::Permissions>,
 ) -> io::Result<File> {
+    if permissions.map_or(false, |p| p.readonly()) {
+        return not_supported("changing permissions is not supported on this platform");
+    }
     open_options
         .create_new(true)
         .read(true)

--- a/src/file/imp/windows.rs
+++ b/src/file/imp/windows.rs
@@ -19,7 +19,11 @@ fn to_utf16(s: &Path) -> Vec<u16> {
     s.as_os_str().encode_wide().chain(iter::once(0)).collect()
 }
 
-pub fn create_named(path: &Path, open_options: &mut OpenOptions) -> io::Result<File> {
+pub fn create_named(
+    path: &Path,
+    open_options: &mut OpenOptions,
+    _permissions: Option<&std::fs::Permissions>,
+) -> io::Result<File> {
     open_options
         .create_new(true)
         .read(true)

--- a/src/file/imp/windows.rs
+++ b/src/file/imp/windows.rs
@@ -45,7 +45,8 @@ pub fn create(dir: &Path) -> io::Result<File> {
         OsStr::new(".tmp"),
         OsStr::new(""),
         crate::NUM_RAND_CHARS,
-        |path| {
+        None,
+        |path, _permissions| {
             OpenOptions::new()
                 .create_new(true)
                 .read(true)

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -1107,13 +1107,14 @@ impl<F: AsRawHandle> AsRawHandle for NamedTempFile<F> {
 pub(crate) fn create_named(
     mut path: PathBuf,
     open_options: &mut OpenOptions,
+    permissions: Option<&std::fs::Permissions>,
 ) -> io::Result<NamedTempFile> {
     // Make the path absolute. Otherwise, changing directories could cause us to
     // delete the wrong file.
     if !path.is_absolute() {
         path = env::current_dir()?.join(path)
     }
-    imp::create_named(&path, open_options)
+    imp::create_named(&path, open_options, permissions)
         .with_err_path(|| path.clone())
         .map(|file| NamedTempFile {
             path: TempPath {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ pub struct Builder<'a, 'b> {
     prefix: &'a OsStr,
     suffix: &'b OsStr,
     append: bool,
+    permissions: Option<std::fs::Permissions>,
 }
 
 impl<'a, 'b> Default for Builder<'a, 'b> {
@@ -206,6 +207,7 @@ impl<'a, 'b> Default for Builder<'a, 'b> {
             prefix: OsStr::new(".tmp"),
             suffix: OsStr::new(""),
             append: false,
+            permissions: None,
         }
     }
 }
@@ -396,6 +398,63 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// ```
     pub fn append(&mut self, append: bool) -> &mut Self {
         self.append = append;
+        self
+    }
+
+    /// The permissions to create the tempfile with.
+    /// This allows to them differ from the default mode of `0o600` on Unix.
+    ///
+    /// # Security
+    ///
+    /// By default, the permissions of tempfiles on unix are set for it to be
+    /// readable and writable by the owner only, yielding the greatest amount
+    /// of security.
+    /// As this method allows to widen the permissions, security would be
+    /// reduced in such cases.
+    ///
+    /// # Platform Notes
+    /// ## Unix
+    ///
+    /// The actual permission bits set on the tempfile will be affected by the
+    /// `umask` applied by the underlying `open` syscall.
+    ///
+    /// ## Windows and others
+    ///
+    /// This setting is ignored.
+    ///
+    /// # Limitations
+    ///
+    /// Permissions for directories aren't currently set even though it would
+    /// be possible on Unix systems.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::io;
+    /// # fn main() {
+    /// #     if let Err(_) = run() {
+    /// #         ::std::process::exit(1);
+    /// #     }
+    /// # }
+    /// # fn run() -> Result<(), io::Error> {
+    /// # use tempfile::Builder;
+    /// #[cfg(unix)]
+    /// {
+    ///     use std::os::unix::fs::PermissionsExt;
+    ///     let all_read_write = std::fs::Permissions::from_mode(0o666);
+    ///     let tempfile = Builder::new().permissions(all_read_write).tempfile()?;
+    ///     let actual_permissions = tempfile.path().metadata()?.permissions();
+    ///     assert_ne!(
+    ///         actual_permissions.mode() & !0o170000,
+    ///         0o600,
+    ///         "we get broader permissions than the default despite umask"
+    ///     );
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn permissions(&mut self, permissions: std::fs::Permissions) -> &mut Self {
+        self.permissions = Some(permissions);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,16 @@ impl<'a, 'b> Builder<'a, 'b> {
             self.prefix,
             self.suffix,
             self.random_len,
-            |path| file::create_named(path, OpenOptions::new().append(self.append)),
+            |path| {
+                let mut open_options = OpenOptions::new();
+                open_options.append(self.append);
+                #[cfg(all(unix, not(target_os = "wasi")))]
+                {
+                    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+                    open_options.mode(self.permissions.as_ref().map(|p| p.mode()).unwrap_or(0o600));
+                }
+                file::create_named(path, &mut open_options)
+            },
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,14 +533,11 @@ impl<'a, 'b> Builder<'a, 'b> {
             self.suffix,
             self.random_len,
             |path| {
-                let mut open_options = OpenOptions::new();
-                open_options.append(self.append);
-                #[cfg(all(unix, not(target_os = "wasi")))]
-                {
-                    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-                    open_options.mode(self.permissions.as_ref().map(|p| p.mode()).unwrap_or(0o600));
-                }
-                file::create_named(path, &mut open_options)
+                file::create_named(
+                    path,
+                    OpenOptions::new().append(self.append),
+                    self.permissions.as_ref(),
+                )
             },
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,7 +420,8 @@ impl<'a, 'b> Builder<'a, 'b> {
     ///
     /// ## Windows and others
     ///
-    /// This setting is ignored.
+    /// This setting is unsupported and trying to set a file or directory read-only
+    /// will cause an error to be returned..
     ///
     /// # Limitations
     ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,7 +20,8 @@ pub fn create_helper<R>(
     prefix: &OsStr,
     suffix: &OsStr,
     random_len: usize,
-    mut f: impl FnMut(PathBuf) -> io::Result<R>,
+    permissions: Option<&std::fs::Permissions>,
+    mut f: impl FnMut(PathBuf, Option<&std::fs::Permissions>) -> io::Result<R>,
 ) -> io::Result<R> {
     let num_retries = if random_len != 0 {
         crate::NUM_RETRIES
@@ -30,7 +31,7 @@ pub fn create_helper<R>(
 
     for _ in 0..num_retries {
         let path = base.join(tmpname(prefix, suffix, random_len));
-        return match f(path) {
+        return match f(path, permissions) {
             Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists && num_retries > 1 => continue,
             // AddrInUse can happen if we're creating a UNIX domain socket and
             // the path already exists.


### PR DESCRIPTION
This PR allows the user to control the file mode set for newly created `NameTempfile` instances.

This is paramount for when tempfiles are used as scratch space that will be persisted and renamed into the final destination once all writes are completed. This is an effective way to prevent half-written files on disk and to assure that readers can only observe the final result of a change.

This paradigm is implemented in the `gix-lock` crate which is used by the `gix-ref` crate for editing Git references. Currently these are created with `0o600` permissions, which can cause [issues when using `sudo`](https://github.com/stacked-git/stgit/issues/413) in downstream applications.

When this PR is merged, `gix-ref` can be adjusted to allow setting the mode [just like Git does](https://github.com/git/git/blob/master/lockfile.h#L175-L181).

### Review Notes

I did my best to adapt the least amount of code while staying true to the current organisation.  Initially I named the new method `mode`, but realized that `std::fs::Permissions` exists which would allow the API to be more general, despite only one available platform for implementation.

Let me explain the commits in some detail and why it's one more than needed:

* the first commit is a failing test that adds the new `Builder` method without an implementation. CI is red to show it's not working.
* the second commits implements it to be least invasive, which violates the principle that platform dependent code should remain in `imp`. CI is green.
* the third commit implements it so that `permissions` can be passed down to the platforms, which is more invasive, yet cleaner. CI is also green.

Please let me know which way you prefer as its also a trade-off.

