### PR TITLE
chore: fix doc url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/tempfile/latest/tempfile"
+    html_root_url = "https://docs.rs/tempfile/latest"
 )]
 #![cfg_attr(test, deny(warnings))]
 #![deny(rust_2018_idioms)]


### PR DESCRIPTION
It has to end with version (or latest).
Fixes ecb73745c552f9df53f8943ea80e9bebf51643a2.

Just checked. Otherwise the links are broken. Sorry for the second push into the previous branch.