### PR TITLE
Make tempfile robust against TLS deallocation

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -4,20 +4,7 @@ use std::{io, iter::repeat_with};
 
 use crate::error::IoResultExt;
 
-fn tmpname(prefix: &OsStr, suffix: &OsStr, rand_len: usize) -> OsString {
-    let capacity = prefix
-        .len()
-        .saturating_add(suffix.len())
-        .saturating_add(rand_len);
-    let mut buf = OsString::with_capacity(capacity);
-    buf.push(prefix);
-    let mut char_buf = [0u8; 4];
-    for c in repeat_with(fastrand::alphanumeric).take(rand_len) {
-        buf.push(c.encode_utf8(&mut char_buf));
-    }
-    buf.push(suffix);
-    buf
-}
+use fastrand::Rng;
 
 pub fn create_helper<R>(
     base: &Path,
@@ -27,12 +14,29 @@ pub fn create_helper<R>(
     permissions: Option<&std::fs::Permissions>,
     mut f: impl FnMut(PathBuf, Option<&std::fs::Permissions>) -> io::Result<R>,
 ) -> io::Result<R> {
+    let capacity = prefix
+        .len()
+        .saturating_add(random_len)
+        .saturating_add(suffix.len());
+    let mut buf = OsString::with_capacity(capacity);
+
     if random_len == 0 {
-        let path = base.join(tmpname(prefix, suffix, random_len));
+        buf.push(prefix);
+        buf.push(suffix);
+        let path = base.join(buf);
         f(path, permissions)
     } else {
+        let mut char_buf = [0u8; 4];
+        let mut rng = Rng::new();
+
         for _ in 0..crate::NUM_RETRIES {
-            let path = base.join(tmpname(prefix, suffix, random_len));
+            buf.push(prefix);
+            for c in repeat_with(|| rng.alphanumeric()).take(random_len) {
+                buf.push(c.encode_utf8(&mut char_buf));
+            }
+            buf.push(suffix);
+            let path = base.join(&buf);
+            buf.clear();
             return match f(path, permissions) {
                 Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
                 // AddrInUse can happen if we're creating a UNIX domain socket and


### PR DESCRIPTION
This PR is a result of discussion at https://github.com/smol-rs/fastrand/pull/77.

Right now the fastrand implementation is robust with current Rust implementation against TLS deallocation issues, because the Rng struct does not require any form of drop, so the TLS memory is kept in tact. At least I was unable to provoke an issue in any way.

Even if Rust changes at some time and `mem::needs_drop` starts returning `true` for `Rng`, the instantiation of a new Rng will succeed. Unfortunately, it won't be random at that point, because the seed is a constant value in this case. See https://github.com/smol-rs/fastrand/blob/dda0fe824b078bc844300db86021c2552465c468/src/global_rng.rs#L26 for implementation.

It really depends if tempfile is actually supposed to be functional during TLS deallocation (i.e. while thread local storages are dropped). If this is no goal, this PR can simply be closed.