### PR TITLE
plumbing for `with_suffix` for issue #298

### DIFF
--- a/src/dir/mod.rs
+++ b/src/dir/mod.rs
@@ -267,6 +267,58 @@ impl TempDir {
         Builder::new().prefix(&prefix).tempdir()
     }
 
+    /// Attempts to make a temporary directory with the specified suffix inside of
+    /// `env::temp_dir()`. The directory and everything inside it will be automatically
+    /// deleted once the returned `TempDir` is destroyed.
+    ///
+    /// # Errors
+    ///
+    /// If the directory can not be created, `Err` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fs::{self, File};
+    /// use std::io::Write;
+    /// use tempfile::TempDir;
+    ///
+    /// // Create a directory inside of the current directory
+    /// let tmp_dir = TempDir::with_suffix("-foo")?;
+    /// let tmp_name = tmp_dir.path().file_name().unwrap().to_str().unwrap();
+    /// assert!(tmp_name.ends_with("-foo"));
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
+    pub fn with_suffix<S: AsRef<OsStr>>(suffix: S) -> io::Result<TempDir> {
+        Builder::new().suffix(&suffix).tempdir()
+    }
+    /// Attempts to make a temporary directory with the specified prefix inside
+    /// the specified directory. The directory and everything inside it will be
+    /// automatically deleted once the returned `TempDir` is destroyed.
+    ///
+    /// # Errors
+    ///
+    /// If the directory can not be created, `Err` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fs::{self, File};
+    /// use std::io::Write;
+    /// use tempfile::TempDir;
+    ///
+    /// // Create a directory inside of the current directory
+    /// let tmp_dir = TempDir::with_suffix_in("-foo", ".")?;
+    /// let tmp_name = tmp_dir.path().file_name().unwrap().to_str().unwrap();
+    /// assert!(tmp_name.ends_with("-foo"));
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
+    pub fn with_suffix_in<S: AsRef<OsStr>, P: AsRef<Path>>(
+        suffix: S,
+        dir: P,
+    ) -> io::Result<TempDir> {
+        Builder::new().suffix(&suffix).tempdir_in(dir)
+    }
+
     /// Attempts to make a temporary directory with the specified prefix inside
     /// the specified directory. The directory and everything inside it will be
     /// automatically deleted once the returned `TempDir` is destroyed.

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -577,6 +577,33 @@ impl NamedTempFile<File> {
         Builder::new().tempfile_in(dir)
     }
 
+    /// Create a new named temporary file with the specified filename suffix.
+    ///
+    /// See [`NamedTempFile::new()`] for details.
+    ///
+    /// [`NamedTempFile::new()`]: #method.new
+    pub fn with_suffix<S: AsRef<OsStr>>(suffix: S) -> io::Result<NamedTempFile> {
+        Builder::new().suffix(&suffix).tempfile()
+    }
+    /// Create a new named temporary file with the specified filename suffix,
+    /// in the specified directory.
+    ///
+    /// This is equivalent to:
+    ///
+    /// ```ignore
+    /// Builder::new().suffix(&suffix).tempfile_in(directory)
+    /// ```
+    ///
+    /// See [`NamedTempFile::new()`] for details.
+    ///
+    /// [`NamedTempFile::new()`]: #method.new
+    pub fn with_suffix_in<S: AsRef<OsStr>, P: AsRef<Path>>(
+        suffix: S,
+        dir: P,
+    ) -> io::Result<NamedTempFile> {
+        Builder::new().suffix(&suffix).tempfile_in(dir)
+    }
+
     /// Create a new named temporary file with the specified filename prefix.
     ///
     /// See [`NamedTempFile::new()`] for details.

--- a/tests/namedtempfile.rs
+++ b/tests/namedtempfile.rs
@@ -18,6 +18,13 @@ fn test_prefix() {
 }
 
 #[test]
+fn test_suffix() {
+    let tmpfile = NamedTempFile::with_suffix("suffix").unwrap();
+    let name = tmpfile.path().file_name().unwrap().to_str().unwrap();
+    assert!(name.ends_with("suffix"));
+}
+
+#[test]
 fn test_basic() {
     let mut tmpfile = NamedTempFile::new().unwrap();
     write!(tmpfile, "abcde").unwrap();

--- a/tests/tempdir.rs
+++ b/tests/tempdir.rs
@@ -33,6 +33,12 @@ fn test_prefix() {
     assert!(name.starts_with("prefix"));
 }
 
+fn test_suffix() {
+    let tmpfile = TempDir::with_suffix_in("suffix", ".").unwrap();
+    let name = tmpfile.path().file_name().unwrap().to_str().unwrap();
+    assert!(name.ends_with("suffix"));
+}
+
 fn test_customnamed() {
     let tmpfile = Builder::new()
         .prefix("prefix")
@@ -175,6 +181,7 @@ fn test_keep() {
 fn main() {
     in_tmpdir(test_tempdir);
     in_tmpdir(test_prefix);
+    in_tmpdir(test_suffix);
     in_tmpdir(test_customnamed);
     in_tmpdir(test_rm_tempdir);
     in_tmpdir(test_rm_tempdir_close);


### PR DESCRIPTION
closes #298 

Adds a `with_suffix` to correspond to `with_prefix`. Allows for easier filetype specification and naming.