### PR TITLE
allow older windows-sys 0.52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ once_cell = { version = "1.19.0", default-features = false, features = ["std"] }
 rustix = { version = "0.38.37", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.59"
+version = ">=0.52,<=0.59"
 features = [
     "Win32_Storage_FileSystem",
     "Win32_Foundation",


### PR DESCRIPTION
dependabot bumped the version to 0.59 but older version 0.52 can also be supported allowing downstream crates to pull dependency as per their version choice.