### PR TITLE
fix: enable wasip2 feature for wasm32-wasip2 target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,18 @@ jobs:
           targets: wasm32-wasip1
       - name: Build
         run: cargo build --target wasm32-wasip1 --features nightly
+  wasip2:
+    name: WASI P2 Test Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: wasm32-wasip2
+      - name: Build
+        run: cargo build --target wasm32-wasip2 --features nightly
   wasm:
     name: WASM Test Build
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,3 @@ doc-comment = "0.3"
 
 [features]
 nightly = []
-unstable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ doc-comment = "0.3"
 
 [features]
 nightly = []
+unstable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ fastrand = "2.1.1"
 once_cell = { version = "1.19.0", default-features = false, features = ["std"] }
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
-rustix = { version = "0.38.37", features = ["fs"] }
+rustix = { version = "0.38.39", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = ">=0.52,<=0.59"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// wasip2 conditionally gates stdlib APIs.
+// https://github.com/rust-lang/rust/issues/130323
+#![cfg_attr(all(target_os = "wasi", target_env = "p2"), feature(wasip2))]
 //! Temporary files and directories.
 //!
 //! - Use the [`tempfile()`] function for temporary files

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,3 @@
-// wasip2 conditionally gates stdlib APIs.
-// https://github.com/rust-lang/rust/issues/130323
-#![cfg_attr(
-    all(target_os = "wasi", target_env = "p2", feature = "unstable"),
-    feature(wasip2)
-)]
 //! Temporary files and directories.
 //!
 //! - Use the [`tempfile()`] function for temporary files
@@ -142,6 +136,12 @@
 #![cfg_attr(test, deny(warnings))]
 #![deny(rust_2018_idioms)]
 #![allow(clippy::redundant_field_names)]
+// wasip2 conditionally gates stdlib APIs.
+// https://github.com/rust-lang/rust/issues/130323
+#![cfg_attr(
+    all(feature = "nightly", target_os = "wasi", target_env = "p2"),
+    feature(wasip2)
+)]
 #![cfg_attr(all(feature = "nightly", target_os = "wasi"), feature(wasi_ext))]
 
 #[cfg(doctest)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 // wasip2 conditionally gates stdlib APIs.
 // https://github.com/rust-lang/rust/issues/130323
-#![cfg_attr(all(target_os = "wasi", target_env = "p2"), feature(wasip2))]
+#![cfg_attr(
+    all(target_os = "wasi", target_env = "p2", feature = "unstable"),
+    feature(wasip2)
+)]
 //! Temporary files and directories.
 //!
 //! - Use the [`tempfile()`] function for temporary files


### PR DESCRIPTION
- wasip2 will require +nightly until https://github.com/rust-lang/rust/issues/130323 is resolved and/or std::os::wasip2 is available in stable.
- Support was added to rustix for version 0.38.39 https://github.com/bytecodealliance/rustix/pull/1205