### PR TITLE
Add stored parent_dir builder parameter

### DIFF
--- a/tests/tempdir.rs
+++ b/tests/tempdir.rs
@@ -39,6 +39,18 @@ fn test_suffix() {
     assert!(name.ends_with("suffix"));
 }
 
+fn test_stored_parent_dir() {
+    let parent = TempDir::new().unwrap();
+    let child = Builder::new().parent_dir(parent.path()).tempdir().unwrap();
+    let path_str = child.path().to_str().unwrap();
+    assert!(
+        path_str.starts_with(child.path().to_str().unwrap()),
+        "{:?} not in {:?}",
+        child,
+        parent
+    );
+}
+
 fn test_customnamed() {
     let tmpfile = Builder::new()
         .prefix("prefix")
@@ -182,6 +194,8 @@ fn main() {
     in_tmpdir(test_tempdir);
     in_tmpdir(test_prefix);
     in_tmpdir(test_suffix);
+    in_tmpdir(test_suffix);
+    in_tmpdir(test_stored_parent_dir);
     in_tmpdir(test_customnamed);
     in_tmpdir(test_rm_tempdir);
     in_tmpdir(test_rm_tempdir_close);

--- a/tests/tempfile.rs
+++ b/tests/tempfile.rs
@@ -8,6 +8,8 @@ use std::{
     thread,
 };
 
+use tempfile::{Builder, TempDir};
+
 #[test]
 fn test_basic() {
     let mut tmpfile = tempfile::tempfile().unwrap();
@@ -17,6 +19,20 @@ fn test_basic() {
     tmpfile.read_to_string(&mut buf).unwrap();
     assert_eq!("abcde", buf);
 }
+
+#[test]
+fn test_stored_parent_dir() {
+    let parent = TempDir::new().unwrap();
+    let child = Builder::new().parent_dir(parent.path()).tempfile().unwrap();
+    let path_str = child.path().to_str().unwrap();
+    assert!(
+        path_str.starts_with(child.path().to_str().unwrap()),
+        "{:?} not in {:?}",
+        child,
+        parent
+    );
+}
+
 
 #[test]
 fn test_cleanup() {


### PR DESCRIPTION
I have a usecase where it's useful to be able to pass `Builder`s around and have them remember the parent directory to create files in, just like they remember the filename prefix and suffix.

So, add a new `parent_dir` API to do just that.

Note that we still call env::temp_dir even when the result won't be used. Using `self.dir.unwrap_or_else(|| temp_dir())` doesn't work because `tempdir_in` doesn't accept an owned `PathBuf`. If anyone prefers, we can easily get rid of this pointless call by just having an explicit `match` instead of `unwrap_or`, but it's a bit more verbose. No strong feelings either way from my side.