### PR TITLE
Fix link to ticket in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.14.0
 
 - Make the wasip2 target work (requires tempfile's "nightly" feature to be enabled). [#305](https://github.com/Stebalien/tempfile/pull/305).
-- Allow older windows-sys versions [#304](https://github.com/Stebalien/tempfile/pull/305).
+- Allow older windows-sys versions [#304](https://github.com/Stebalien/tempfile/pull/304).
 
 ## 3.13.0
 


### PR DESCRIPTION
I clicked the link to learn from the ticket - and found it went to the wrong ticket.