### PR TITLE
docs: improve & expand security documentation

### DIFF
--- a/src/dir/mod.rs
+++ b/src/dir/mod.rs
@@ -22,14 +22,19 @@ use crate::env;
 
 /// Create a new temporary directory.
 ///
-/// The `tempdir` function creates a directory in the file system
-/// and returns a [`TempDir`].
-/// The directory will be automatically deleted when the `TempDir`s
+/// The `tempdir` function creates a directory in the file system and returns a
+/// [`TempDir`]. The directory will be automatically deleted when the `TempDir`'s
 /// destructor is run.
 ///
 /// # Resource Leaking
 ///
 /// See [the resource leaking][resource-leaking] docs on `TempDir`.
+///
+/// # Security
+///
+/// Temporary directories are created with the default permissions unless otherwise
+/// specified via [`Builder::permissions`]. Depending on your platform, this may make
+/// them world-readable.
 ///
 /// # Errors
 ///

--- a/src/env.rs
+++ b/src/env.rs
@@ -8,7 +8,8 @@ static DEFAULT_TEMPDIR: OnceLock<PathBuf> = OnceLock::new();
 
 /// Override the default temporary directory (defaults to [`std::env::temp_dir`]). This function
 /// changes the _global_ default temporary directory for the entire program and should not be called
-/// except in exceptional cases where it's not configured correctly by the platform.
+/// except in exceptional cases where it's not configured correctly by the platform. Applications
+/// should first check if the path returned by [`env::temp_dir`] is acceptable.
 ///
 /// Only the first call to this function will succeed. All further calls will fail with `Err(path)`
 /// where `path` is previously set default temporary directory override.


### PR DESCRIPTION
Alternative to #311 (this patch includes a few miscellaneous documentation fixes from that PR as well).

The previous documentation didn't sufficiently cover permissions issues and mixed all the security concerns into a single section. This patch separates things out into separate sections and hopefully makes all this easier to understand.

This patch also documents the DoS mitigation introduced in #314 (I stared writing this documentation first then decided that I'd rather just fix the DoS vector...).

I've also removed the link to the OWASP documentation to avoid confusing users (their documentation is mostly concerned with low-level C and platform-specific temporary file creation functions).