### PR TITLE
build: upgrade getrandom to v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ fastrand = "2.1.1"
 once_cell = { version = "1.19.0", default-features = false, features = ["std"] }
 
 [target.'cfg(any(unix, windows, target_os = "wasi"))'.dependencies]
-getrandom = { version = "0.2.15", default-features = false, optional = true }
+getrandom = { version = "0.3.0", default-features = false, optional = true }
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
 rustix = { version = "0.38.39", features = ["fs"] }

--- a/src/util.rs
+++ b/src/util.rs
@@ -47,7 +47,7 @@ pub fn create_helper<R>(
         ))]
         if i == 3 {
             let mut seed = [0u8; 8];
-            if getrandom::getrandom(&mut seed).is_ok() {
+            if getrandom::fill(&mut seed).is_ok() {
                 fastrand::seed(u64::from_ne_bytes(seed));
             }
         }


### PR DESCRIPTION
This upgrades to `getrandom` v0.3, which was released today.
Changelog: https://github.com/rust-random/getrandom/blob/master/CHANGELOG.md#030---2025-01-25

It may make sense to wait a bit before releasing this upgrade as the rest of the ecosystem (including `rand`) hasn't upgraded yet.