### PR TITLE
fix: always use absolute paths

### DIFF
--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -1043,16 +1043,11 @@ impl<F: AsRawHandle> AsRawHandle for NamedTempFile<F> {
 }
 
 pub(crate) fn create_named(
-    mut path: PathBuf,
+    path: PathBuf,
     open_options: &mut OpenOptions,
     permissions: Option<&std::fs::Permissions>,
     keep: bool,
 ) -> io::Result<NamedTempFile> {
-    // Make the path absolute. Otherwise, changing directories could cause us to
-    // delete the wrong file.
-    if !path.is_absolute() {
-        path = std::env::current_dir()?.join(path)
-    }
     imp::create_named(&path, open_options, permissions)
         .with_err_path(|| path.clone())
         .map(|file| NamedTempFile {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -604,17 +604,13 @@ impl<'a, 'b> Builder<'a, 'b> {
     ///
     /// [resource-leaking]: struct.TempDir.html#resource-leaking
     pub fn tempdir_in<P: AsRef<Path>>(&self, dir: P) -> io::Result<TempDir> {
-        let storage;
-        let mut dir = dir.as_ref();
-        if !dir.is_absolute() {
-            let cur_dir = std::env::current_dir()?;
-            storage = cur_dir.join(dir);
-            dir = &storage;
-        }
-
-        util::create_helper(dir, self.prefix, self.suffix, self.random_len, |path| {
-            dir::create(path, self.permissions.as_ref(), self.keep)
-        })
+        util::create_helper(
+            dir.as_ref(),
+            self.prefix,
+            self.suffix,
+            self.random_len,
+            |path| dir::create(path, self.permissions.as_ref(), self.keep),
+        )
     }
 
     /// Attempts to create a temporary file (or file-like object) using the

--- a/tests/namedtempfile.rs
+++ b/tests/namedtempfile.rs
@@ -291,6 +291,16 @@ fn test_change_dir() {
 }
 
 #[test]
+fn test_change_dir_make() {
+    std::env::set_current_dir(env::temp_dir()).unwrap();
+    let tmpfile = Builder::new().make_in(".", |p| File::create(p)).unwrap();
+    let path = std::env::current_dir().unwrap().join(tmpfile.path());
+    std::env::set_current_dir("/").unwrap();
+    drop(tmpfile);
+    assert!(!exists(path))
+}
+
+#[test]
 fn test_into_parts() {
     let mut file = NamedTempFile::new().unwrap();
     write!(file, "abcd").expect("write failed");


### PR DESCRIPTION
We used absolute paths in the builder when making directories and in `create_named` but this didn't cover `Builder::make_in` and technically introduced a small race in some unnamed tempfile cases (i.e., when we can't atomically create unnamed temporary files and need to create then immediately delete them).

Instead, we now resolve the filename into an absolute path inside the main create helper.