### PR TITLE
fix: cast handle to the windows crate HANDLE

### DIFF
--- a/src/file/imp/windows.rs
+++ b/src/file/imp/windows.rs
@@ -31,7 +31,7 @@ fn delete_open_file(f: &File) -> io::Result<()> {
             Flags: FILE_DISPOSITION_FLAG_DELETE | FILE_DISPOSITION_FLAG_POSIX_SEMANTICS,
         };
         if SetFileInformationByHandle(
-            f.as_raw_handle(),
+            f.as_raw_handle() as HANDLE,
             FileDispositionInfoEx,
             &info as *const _ as *const _,
             std::mem::size_of::<FILE_DISPOSITION_INFO_EX>() as u32,


### PR DESCRIPTION
This isn't necessary for windows-sys 0.59, but is for windows-sys 0.52.

fixes #331