### PR TITLE
chore: remove cfg-if dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ repository = "https://github.com/Stebalien/tempfile"
 description = "A library for managing temporary files and directories."
 
 [dependencies]
-cfg-if = "1"
 fastrand = "2.1.1"
 # Not available in stdlib until 1.70, but we support 1.63 to support Debian stable.
 once_cell = { version = "1.19.0", default-features = false, features = ["std"] }

--- a/src/file/imp/mod.rs
+++ b/src/file/imp/mod.rs
@@ -1,12 +1,9 @@
-cfg_if::cfg_if! {
-    if #[cfg(any(unix, target_os = "redox", target_os = "wasi"))] {
-        mod unix;
-        pub use self::unix::*;
-    } else if #[cfg(windows)] {
-        mod windows;
-        pub use self::windows::*;
-    } else {
-        mod other;
-        pub use self::other::*;
-    }
-}
+#[cfg_attr(any(unix, target_os = "redox", target_os = "wasi"), path = "unix.rs")]
+#[cfg_attr(windows, path = "windows.rs")]
+#[cfg_attr(
+    not(any(unix, target_os = "redox", target_os = "wasi", windows)),
+    path = "other.rs"
+)]
+mod platform;
+
+pub use self::platform::*;

--- a/src/file/imp/unix.rs
+++ b/src/file/imp/unix.rs
@@ -1,14 +1,7 @@
 use std::ffi::OsStr;
 use std::fs::{self, File, OpenOptions};
 use std::io;
-cfg_if::cfg_if! {
-    if #[cfg(not(target_os = "wasi"))] {
-        use std::os::unix::fs::MetadataExt;
-    } else {
-        #[cfg(feature = "nightly")]
-        use std::os::wasi::fs::MetadataExt;
-    }
-}
+
 use crate::util;
 use std::path::Path;
 
@@ -88,6 +81,11 @@ fn create_unix(dir: &Path) -> io::Result<File> {
 
 #[cfg(any(not(target_os = "wasi"), feature = "nightly"))]
 pub fn reopen(file: &File, path: &Path) -> io::Result<File> {
+    #[cfg(not(target_os = "wasi"))]
+    use std::os::unix::fs::MetadataExt;
+    #[cfg(target_os = "wasi")]
+    use std::os::wasi::fs::MetadataExt;
+
     let new_file = OpenOptions::new().read(true).write(true).open(path)?;
     let old_meta = file.metadata()?;
     let new_meta = new_file.metadata()?;


### PR DESCRIPTION
It's tiny, but we don't really need it so we might as well trim our dependencies down a bit.