### PR TITLE
feat(windows): add a feature to immediate tempfile deletion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ doc-comment = "0.3"
 [features]
 default = ["getrandom"]
 nightly = []
+# Disables immediate deletion of newly opened tempfiles on windows, instead relying on the old
+# "delete on close" behavior. This will hopefully fix #339.
+unstable-windows-keep-open-tempfile = []

--- a/src/file/imp/windows.rs
+++ b/src/file/imp/windows.rs
@@ -76,6 +76,7 @@ pub fn create(dir: &Path) -> io::Result<File> {
                 .open(path)?;
             // Attempt to delete the file by-handle. If this fails, do nothing; the file will be
             // deleted on close anyways.
+            #[cfg(not(feature = "unstable-windows-keep-open-tempfile"))]
             let _ = delete_open_file(&f);
             Ok(f)
         },


### PR DESCRIPTION
This adds a feature making it possible to disable the immediate deletion of unnamed temporary files on windows (introduced in 461369fd). Hopefully, this will fix #339. If so, I'll revert 461369fd entirely.