### PR TITLE
ci: downgrade once-cell on old rustc versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust-version }}
+      - name: Generating the Cargo.lock
+        run: cargo generate-lockfile
+      - name: Downgrading once_cell
+        if: matrix.rust-version == 1.63
+        run: cargo update -p once_cell --precise 1.20.3
       - name: Build
         run: cargo build
       - name: Test


### PR DESCRIPTION
I'm doing this in CI instead of in the Cargo.toml file because I don't want to force users of newer rustc versions to use old versions of `once_cell`. Ironically, I only depend on `once_cell` to support ancient rust versions in the first place.