### PR TITLE
fix(windows): don't automatically delete files on open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.19.1 [unreleased]
+
+- Don't unlink temporary files immediately on Windows (fixes #339). Unfortunately, this seemed to corrupt the file object (possibly a Windows kernel bug) in rare cases and isn't strictly speaking necessary.
+
 ## 3.19.0
 
 - Remove direct dependency on `cfg-if`. It's still in the tree, but we didn't really need to use it in this crate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,5 @@ doc-comment = "0.3"
 [features]
 default = ["getrandom"]
 nightly = []
-# Disables immediate deletion of newly opened tempfiles on windows, instead relying on the old
-# "delete on close" behavior. This will hopefully fix #339.
+# DEPRECATED unstable feature, will be removed in the near future.
 unstable-windows-keep-open-tempfile = []


### PR DESCRIPTION
We tried doing this to match the behavior on Unix platforms but this appears to trigger some form of Windows kernel bug at scale. Given that it's not necessary, we're reverting it. I'm leaving the feature flag in the `Cargo.toml` for now but will remove it in the near future.

fixes #339