### PR TITLE
Build docs.rs documentation with rustdoc jump to def feature enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ default = ["getrandom"]
 nightly = []
 # DEPRECATED unstable feature, will be removed in the near future.
 unstable-windows-keep-open-tempfile = []
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]


### PR DESCRIPTION
I was reading source code on docs.rs and realized that the feature was not enabled, so here it is. :)

Enabling this feature makes your source code pages generate links on items so you can jump to where they're defined.

You can this feature in action in [`syn`](https://docs.rs/syn/latest/src/syn/lib.rs.html#986-1010) for example.