### PR TITLE
feat: rename `TempDir::into_path` to `TempDir::keep`

### DIFF
--- a/src/dir/mod.rs
+++ b/src/dir/mod.rs
@@ -382,6 +382,13 @@ impl TempDir {
         self.path.as_ref()
     }
 
+    /// Deprecated alias for [`TempDir::keep`].
+    #[must_use]
+    #[deprecated = "use TempDir::keep()"]
+    pub fn into_path(self) -> PathBuf {
+        self.keep()
+    }
+
     /// Persist the temporary directory to disk, returning the [`PathBuf`] where it is located.
     ///
     /// This consumes the [`TempDir`] without deleting directory on the filesystem, meaning that
@@ -400,14 +407,13 @@ impl TempDir {
     ///
     /// // Persist the temporary directory to disk,
     /// // getting the path where it is.
-    /// let tmp_path = tmp_dir.into_path();
+    /// let tmp_path = tmp_dir.keep();
     ///
     /// // Delete the temporary directory ourselves.
     /// fs::remove_dir_all(tmp_path)?;
     /// # Ok::<(), std::io::Error>(())
     /// ```
-    #[must_use]
-    pub fn into_path(self) -> PathBuf {
+    pub fn keep(self) -> PathBuf {
         // Prevent the Drop impl from being called.
         let mut this = mem::ManuallyDrop::new(self);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,7 +469,8 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// [`NamedTempFile`]/[`TempDir`]. When `keep` is set to `true`, this behavior is suppressed.
     ///
     /// If you wish to keep a temporary file or directory after creating it, call
-    /// [`NamedTempFile::keep`] or [`TempDir::into_path`] respectively.
+    /// [`NamedTempFile::keep`] or [`TempDir::keep`] respectively to turn it into a regular
+    /// file/path (respectively) that won't be automatically deleted.
     ///
     /// # Examples
     ///

--- a/tests/tempdir.rs
+++ b/tests/tempdir.rs
@@ -85,7 +85,7 @@ fn test_rm_tempdir() {
     let path;
     {
         let tmp = TempDir::new().unwrap();
-        path = tmp.into_path();
+        path = tmp.keep();
     }
     assert!(path.exists());
     fs::remove_dir_all(&path).unwrap();
@@ -128,7 +128,7 @@ fn test_rm_tempdir_close() {
     let path;
     {
         let tmp = TempDir::new().unwrap();
-        path = tmp.into_path();
+        path = tmp.keep();
     }
     assert!(path.exists());
     fs::remove_dir_all(&path).unwrap();


### PR DESCRIPTION
This unifies the `TempDir`/`NamedTempFile` method names to help avoid confusion.