### PR TITLE
ci: test macos on aarch64 instead of x86

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
             target: x86_64-pc-windows-msvc
           - name: "MacOS"
             os: macos-latest
-            target: x86_64-apple-darwin
+            target: aarch64-apple-darwin
         include:
           - rust-version: "nightly"
             platform:


### PR DESCRIPTION
This is what most people will be using at this point, and this is the target machine architecture anyways.