### PR TITLE
docs: Remove mention of deprecated function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,8 +466,7 @@ impl<'a, 'b> Builder<'a, 'b> {
     }
 
     /// Disable cleanup of the file/folder to even when the [`NamedTempFile`]/[`TempDir`] goes out
-    /// of scope. Prefer [`NamedTempFile::keep`] and `[`TempDir::keep`] where possible,
-    /// `disable_cleanup` is provided for testing & debugging.
+    /// of scope.
     ///
     /// By default, the file/folder is automatically cleaned up in the destructor of
     /// [`NamedTempFile`]/[`TempDir`]. When `disable_cleanup` is set to `true`, this behavior is


### PR DESCRIPTION
`keep` is marked as deprecated in favor of `disable_cleanup` - so `disable_cleanup` should not recommend using `keep`.

Not totally sure this is how it's supposed to be used (as these docs are on `Builder`), but in any case the docs seem cyclic.

Let me know what you think!