### PR TITLE
Fix formatting in `Builder::disable_cleanup` documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,7 +470,7 @@ impl<'a, 'b> Builder<'a, 'b> {
     }
 
     /// Disable cleanup of the file/folder to even when the [`NamedTempFile`]/[`TempDir`] goes out
-    /// of scope. Prefer [`NamedTempFile::keep`] and `[`TempDir::keep`] where possible,
+    /// of scope. Prefer [`NamedTempFile::keep`] and [`TempDir::keep`] where possible;
     /// `disable_cleanup` is provided for testing & debugging.
     ///
     /// By default, the file/folder is automatically cleaned up in the destructor of


### PR DESCRIPTION
1. Remove an extra backtick which breaks the markdown formatting:
   <img width="533" height="38" alt="Screenshot 2025-09-13 at 15 15 44" src="https://github.com/user-attachments/assets/51f95749-6d42-4f26-ae89-aa8bece56e60" />
2. Nit, don't feel strongly: use a semicolon between two independent clauses, instead of a comma. Adding "since" after the comma would work too.