### PR TITLE
doc: Update COPYRIGHT link

### DIFF
--- a/src/dir/mod.rs
+++ b/src/dir/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
+// https://github.com/rust-lang/rust/blob/master/COPYRIGHT.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license


### PR DESCRIPTION
The previous link is no longer valid. After checking the [Wayback Machine](https://web.archive.org/web/20150124154549/https://www.rust-lang.org/COPYRIGHT), I found that its contents are similar to https://github.com/rust-lang/rust/blob/master/COPYRIGHT