### PR TITLE
Exclude CI scripts from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Stebalien/tempfile"
 description = "A library for managing temporary files and directories."
 
+include = ["CHANGELOG.md", "Cargo.toml", "LICENSE-*", "README.md", "src/**/*.rs", "tests/**/*.rs"]
+
 [dependencies]
 fastrand = "2.1.1"
 # Not available in stdlib until 1.70, but we support 1.63 to support Debian stable.


### PR DESCRIPTION
During a dependency review we noticed that the tempfile crate includes a CI script. Such CI scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from beeing included in the published packages to make sure that everything that's included is an conscious choice.