### PR TITLE
ci: adds FreeBsd ci using vm runner

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -18,9 +18,6 @@ jobs:
           usesh: true
           prepare: |
             pkg install -y curl git
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-          run: |
-            . $HOME/.cargo/env
-            rustup default stable
+            pkg install -y rust
             cargo build
             cargo test


### PR DESCRIPTION
Adds FreeBSD CI using a VM-based runner.

Addresses #385 by providing build and test coverage on FreeBSD,
unblocking platform-specific changes.