### PR TITLE
ci: restrict permissions to the empty set by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ env:
   ANDROID_VERSION: "12.0.0"
   WASMTIME_BACKTRACE_DETAILS: 1
 
+permissions: {}
+
 name: CI
 jobs:
   deny:

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - master
 
+permissions: {}
 jobs:
   freebsd:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is already the default in the repo settings, but we might as well re-iterate this here.