### PR TITLE
ci: run redox CI without multithreading

### DIFF
--- a/.github/workflows/redox.yml
+++ b/.github/workflows/redox.yml
@@ -10,6 +10,9 @@ on:
 
 permissions: {}
 
+env:
+  REDOXER_QEMU_ARGS: "-smp 1"
+
 jobs:
   redox:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Apparently, upstream support for multithreading isn't great.