### PR TITLE
make test_temp_path_resolve_existing_cwd() work with symlink in TMPDIR

### DIFF
--- a/tests/namedtempfile.rs
+++ b/tests/namedtempfile.rs
@@ -363,13 +363,10 @@ fn test_temp_path_resolve_existing_cwd() {
     let tmpdir = tempdir().unwrap();
     std::env::set_current_dir(&tmpdir).expect("failed to change to directory");
 
-    let cwd = if cfg!(target_os = "macos") {
-        // MacOS has absolute paths and ABSOLUTE paths. `cd /var/tmp/...` actually changes to
-        // /private/var/tmp...
-        std::env::current_dir().expect("failed to get the current directory")
-    } else {
-        tmpdir.path().to_owned()
-    };
+    let cwd = tmpdir
+        .path()
+        .canonicalize()
+        .unwrap_or_else(|_| tmpdir.path().to_owned());
 
     #[allow(deprecated)]
     let path = TempPath::from_path("foo");


### PR DESCRIPTION
Here's a simple way to reproduce a test failure before this commit:

```
ln -s /tmp /tmp/here
TMPDIR=/tmp/here cargo test
```

That fails something like this:

```
test test_temp_path_resolve_existing_cwd ... FAILED

failures:

---- test_temp_path_resolve_existing_cwd stdout ----

thread 'test_temp_path_resolve_existing_cwd' (137617) panicked at tests/namedtempfile.rs:376:5:
assertion `left == right` failed
  left: "/tmp/.tmpDu1A7l/foo"
 right: "/tmp/here/.tmpDu1A7l/foo"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This commit fixes it by canonicalizing the CWD path in the test.