### PR TITLE
Update MSRV to 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         rust-version:
           - nightly
           - stable
-          - "1.63"
+          - "1.70"
         platform:
           - name: "Linux"
             os: ubuntu-latest
@@ -63,18 +63,18 @@ jobs:
             target: wasm32-wasip2
             test-flags: --tests
         exclude:
-          - rust-version: "1.63"
+          - rust-version: "1.70"
             platform:
               name: "Android"
               os: ubuntu-latest
               target: x86_64-linux-android
-          - rust-version: "1.63"
+          - rust-version: "1.70"
             platform:
               name: "WASI P1"
               os: ubuntu-latest
               target: wasm32-wasip1
               test-flags: --tests
-          - rust-version: "1.63"
+          - rust-version: "1.70"
             platform:
               name: "WASI P2"
               os: ubuntu-latest
@@ -95,16 +95,16 @@ jobs:
       - name: Generating the Cargo.lock
         run: cargo generate-lockfile
       - name: Downgrading once_cell
-        if: matrix.rust-version == 1.63
+        if: matrix.rust-version == 1.70
         run: cargo update -p once_cell --precise 1.20.3
       - name: Downgrading windows-sys
-        if: matrix.rust-version == 1.63
+        if: matrix.rust-version == 1.70
         run: cargo update -p windows-sys --precise 0.60.2
       - name: Downgrading getrandom
-        if: matrix.rust-version == 1.63
+        if: matrix.rust-version == 1.70
         run: cargo update -p getrandom --precise 0.3.4
       - name: Downgrading libc
-        if: matrix.rust-version == 1.63
+        if: matrix.rust-version == 1.70
         run: cargo update -p libc --precise 0.2.183
       - name: Install Wasmtime
         if: ${{ startsWith(matrix.platform.target, 'wasm32-wasi') }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 documentation = "https://docs.rs/tempfile"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.70"
 homepage = "https://stebalien.com/projects/tempfile-rs/"
 keywords = ["tempfile", "tmpfile", "filesystem"]
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,6 @@ include = ["CHANGELOG.md", "Cargo.toml", "LICENSE-*", "README.md", "src/**/*.rs"
 
 [dependencies]
 fastrand = "2.1.1"
-# Not available in stdlib until 1.70, but we support 1.63 to support Debian stable.
-once_cell = { version = "1.19.0", default-features = false, features = ["std"] }
 
 [target.'cfg(any(unix, windows, target_os = "wasi"))'.dependencies]
 getrandom = { version = ">=0.3.0, <0.5", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ patterns and surprisingly difficult to implement securely).
 
 ## Usage
 
-Minimum required Rust version: 1.63.0
+Minimum required Rust version: 1.70.0
 
 Add this to your `Cargo.toml`:
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,11 +1,9 @@
 use std::env;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 #[cfg(doc)]
 use crate::{tempdir_in, tempfile_in, Builder};
-
-// Once rust 1.70 is wide-spread (Debian stable), we can use OnceLock from stdlib.
-use once_cell::sync::OnceCell as OnceLock;
 
 static DEFAULT_TEMPDIR: OnceLock<PathBuf> = OnceLock::new();
 

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -7,8 +7,8 @@ use std::mem;
 use std::ops::Deref;
 #[cfg(target_os = "wasi")]
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
-#[cfg(unix)] // we don't use std::os::fd because that's not available on rust 1.63.
-use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
+#[cfg(unix)]
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsHandle, AsRawHandle, BorrowedHandle, RawHandle};
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Debian stable [now supports](https://packages.debian.org/trixie/rust/rustc) rustc 1.85, so I bumped the MSRV to 1.70 to remove `once_cell`.

```
# Not available in stdlib until 1.70, but we support 1.63 to support Debian stable.
once_cell = { version = "1.19.0", default-features = false, features = ["std"] }
``` 